### PR TITLE
[기능 추가] 비회원 기능 예외 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     // WebFlux (WebClient)
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // BadWordFilter (비속어 필터링 라이브러리)
+    implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/org/chzzk/howmeet/domain/common/auth/exception/AuthErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/auth/exception/AuthErrorCode.java
@@ -1,0 +1,20 @@
+package org.chzzk.howmeet.domain.common.auth.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum AuthErrorCode {
+    JWT_EXPIRED("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    JWT_NOT_FOUND("토큰을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
+    JWT_INVALID("토큰이 JWT 형식이 아닙니다.", HttpStatus.UNAUTHORIZED),
+    JWT_INVALID_SUBJECT("토큰내 Subject가 잘못되었습니다.", HttpStatus.UNAUTHORIZED),
+    JWT_FORBIDDEN("토큰에 인가 권한이 없습니다.", HttpStatus.FORBIDDEN);
+    private final String message;
+    private final HttpStatus status;
+
+    AuthErrorCode(final String message, final HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/common/auth/exception/AuthException.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/auth/exception/AuthException.java
@@ -1,0 +1,10 @@
+package org.chzzk.howmeet.domain.common.auth.exception;
+
+public class AuthException extends RuntimeException {
+    private final AuthErrorCode errorCode;
+
+    public AuthException(final AuthErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/common/auth/model/BadWordFilteringSingleton.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/auth/model/BadWordFilteringSingleton.java
@@ -1,0 +1,13 @@
+package org.chzzk.howmeet.domain.common.auth.model;
+
+import com.vane.badwordfiltering.BadWordFiltering;
+
+public class BadWordFilteringSingleton {
+    private static class SingletonInstanceHolder {
+        private static final BadWordFiltering INSTANCE = new BadWordFiltering();
+    }
+
+    public static boolean containsBadWord(final String value) {
+        return SingletonInstanceHolder.INSTANCE.check(value);
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/common/exception/NicknameErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/exception/NicknameErrorCode.java
@@ -1,0 +1,17 @@
+package org.chzzk.howmeet.domain.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum NicknameErrorCode {
+    INVALID_NICKNAME("닉네임이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
+
+    private final String message;
+    private final HttpStatus status;
+
+    NicknameErrorCode(final String message, final HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/common/exception/NicknameException.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/exception/NicknameException.java
@@ -1,0 +1,10 @@
+package org.chzzk.howmeet.domain.common.exception;
+
+public class NicknameException extends RuntimeException {
+    private final NicknameErrorCode errorCode;
+
+    public NicknameException(final NicknameErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/common/model/Nickname.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/model/Nickname.java
@@ -3,6 +3,10 @@ package org.chzzk.howmeet.domain.common.model;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import org.chzzk.howmeet.domain.common.auth.model.BadWordFilteringSingleton;
+import org.chzzk.howmeet.domain.common.exception.NicknameException;
+
+import static org.chzzk.howmeet.domain.common.exception.NicknameErrorCode.INVALID_NICKNAME;
 
 @EqualsAndHashCode
 @Getter
@@ -22,8 +26,8 @@ public class Nickname {
     }
 
     private void validateNickname(final String value) {
-        if (!value.matches(NICKNAME_REGEX)) {
-            throw new IllegalArgumentException();   // todo 8/1 (목) 김민우 : 닉네임은 Guest, Member 모두에 존재하므로 어떤 예외 클래스를 써야될지?
+        if (!value.matches(NICKNAME_REGEX) || BadWordFilteringSingleton.containsBadWord(value)) {
+            throw new NicknameException(INVALID_NICKNAME);
         }
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/common/model/Nickname.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/model/Nickname.java
@@ -12,7 +12,7 @@ import static org.chzzk.howmeet.domain.common.exception.NicknameErrorCode.INVALI
 @Getter
 @ToString
 public class Nickname {
-    private static final String NICKNAME_REGEX = "^(?![-_]{2,10}$)[A-Za-z0-9가-힣]{2,10}$";
+    private static final String NICKNAME_REGEX = "^(?![-_]{2,10}$)[가-힣ㄱ-ㅎㅏ-ㅣA-Za-z0-9_-]{2,10}$";
 
     private final String value;
 

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/exception/GuestErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/exception/GuestErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum GuestErrorCode {
     GUEST_NOT_FOUND("회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    GUEST_ALREADY_EXIST("이미 존재하는 회원입니다.", HttpStatus.BAD_REQUEST),
     INVALID_PASSWORD("비밀번호가 올바르지 않습니다", HttpStatus.BAD_REQUEST);
 
     private final String message;

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestService.java
@@ -16,6 +16,7 @@ import org.chzzk.howmeet.global.util.TokenProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.GUEST_ALREADY_EXIST;
 import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.GUEST_NOT_FOUND;
 
 @RequiredArgsConstructor
@@ -56,7 +57,7 @@ public class GuestService {
 
     private void validateDuplicateNicknameInScheduleId(final Long guestScheduleId, final String nickname) {
         if (guestRepository.existsByGuestScheduleIdAndNickname(guestScheduleId, Nickname.from(nickname))) {
-            throw new GuestException(GUEST_NOT_FOUND);
+            throw new GuestException(GUEST_ALREADY_EXIST);
         }
     }
 

--- a/src/main/java/org/chzzk/howmeet/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/org/chzzk/howmeet/global/interceptor/AuthenticationInterceptor.java
@@ -6,6 +6,7 @@ import com.querydsl.core.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.chzzk.howmeet.domain.common.auth.exception.AuthException;
 import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
 import org.chzzk.howmeet.domain.regular.auth.repository.MemberRepository;
 import org.chzzk.howmeet.domain.temporary.auth.repository.GuestRepository;
@@ -14,6 +15,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import static org.chzzk.howmeet.domain.common.auth.exception.AuthErrorCode.JWT_EXPIRED;
+import static org.chzzk.howmeet.domain.common.auth.exception.AuthErrorCode.JWT_INVALID;
+import static org.chzzk.howmeet.domain.common.auth.exception.AuthErrorCode.JWT_NOT_FOUND;
+import static org.chzzk.howmeet.domain.common.auth.exception.AuthErrorCode.JWT_INVALID_SUBJECT;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Component
@@ -63,8 +68,12 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
     private String getAccessToken(final HttpServletRequest request) {
         final String value = request.getHeader(AUTHORIZATION);
-        if (StringUtils.isNullOrEmpty(value) || !value.startsWith(BEARER_TYPE)) {
-            throw new IllegalArgumentException();
+        if (StringUtils.isNullOrEmpty(value)) {
+            throw new AuthException(JWT_NOT_FOUND);
+        }
+
+        if (!value.startsWith(BEARER_TYPE)) {
+            throw new AuthException(JWT_INVALID);
         }
 
         return value.substring(BEARER_TYPE.length())
@@ -73,14 +82,14 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
     private void validateToken(final String accessToken) {
         if (!tokenProvider.validateToken(accessToken)) {
-            throw new IllegalArgumentException();
+            throw new AuthException(JWT_EXPIRED);
         }
     }
 
     private void validateMember(final AuthPrincipal authPrincipal) {
         final Long id = authPrincipal.id();
         if (!guestRepository.existsById(id) && !memberRepository.existsById(id)) {
-            throw new IllegalArgumentException();
+            throw new AuthException(JWT_INVALID_SUBJECT);
         }
     }
 
@@ -89,7 +98,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             return objectMapper.readValue(tokenProvider.getPayload(accessToken), AuthPrincipal.class);
         } catch (JsonProcessingException e) {
             log.info("AuthPrincipal 변환 중 에러가 발생했습니다. accessToken : {}", accessToken);
-            throw new RuntimeException(e);
+            throw new AuthException(JWT_INVALID_SUBJECT);
         }
     }
 }

--- a/src/main/java/org/chzzk/howmeet/global/interceptor/GuestAuthorityInterceptor.java
+++ b/src/main/java/org/chzzk/howmeet/global/interceptor/GuestAuthorityInterceptor.java
@@ -2,6 +2,7 @@ package org.chzzk.howmeet.global.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.chzzk.howmeet.domain.common.auth.exception.AuthException;
 import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
 import org.chzzk.howmeet.domain.temporary.auth.annotation.TemporaryUser;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,6 +11,8 @@ import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import java.util.Objects;
+
+import static org.chzzk.howmeet.domain.common.auth.exception.AuthErrorCode.JWT_FORBIDDEN;
 
 @Component
 public class GuestAuthorityInterceptor implements HandlerInterceptor {
@@ -38,7 +41,7 @@ public class GuestAuthorityInterceptor implements HandlerInterceptor {
     private void validateGuestAuthorization(final HttpServletRequest request) {
         final AuthPrincipal authPrincipal = (AuthPrincipal) request.getAttribute(authAttributeKey);
         if (!authPrincipal.isGuest()) {
-            throw new IllegalArgumentException();
+            throw new AuthException(JWT_FORBIDDEN);
         }
     }
 }

--- a/src/test/java/org/chzzk/howmeet/common/util/DisplayFormat.java
+++ b/src/test/java/org/chzzk/howmeet/common/util/DisplayFormat.java
@@ -5,5 +5,5 @@ public final class DisplayFormat {
 
     }
 
-    public static final String DISPLAY_NAME_FORMAT = "경우의 수 = {0}, 값 = {1}";
+    public static final String DISPLAY_NAME_FORMAT = "경우 = {0}, 값 = {1}";
 }

--- a/src/test/java/org/chzzk/howmeet/domain/common/model/NicknameTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/common/model/NicknameTest.java
@@ -6,11 +6,31 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.chzzk.howmeet.common.util.DisplayFormat.DISPLAY_NAME_FORMAT;
 import static org.chzzk.howmeet.domain.common.exception.NicknameErrorCode.INVALID_NICKNAME;
 
 class NicknameTest {
+    @ParameterizedTest(name = DISPLAY_NAME_FORMAT)
+    @DisplayName("알파벳(A~Z, a~z), 숫자(0~9), 언더스코어(_), 하이픈(-), 한글(가-힣, 초성, 중성, 종성) 문자 가능")
+    @CsvSource(value = {
+            "알파벳 (대문자), ABCD",
+            "알파벳 (소문자), abcd",
+            "알파벳 (대소문자), ABcd",
+            "숫자, 1234",
+            "언더스코어, h_e",
+            "하이픈, h-e",
+            "한글, 김민우",
+            "한글 (초성), ㄱㅁ민우",
+            "한글 (중성), ㅣㅏ민우",
+            "한글 (종성), ㄲㄳ민우"
+    })
+    public void validCharacters(final String displayName, final String value) throws Exception {
+        assertThatCode(() -> Nickname.from(value))
+                .doesNotThrowAnyException();
+    }
+
     @ParameterizedTest(name = DISPLAY_NAME_FORMAT)
     @DisplayName("닉네임은 2~10자만 가능")
     @CsvSource(value = {
@@ -24,7 +44,7 @@ class NicknameTest {
     }
 
     @ParameterizedTest(name = DISPLAY_NAME_FORMAT)
-    @DisplayName("알파벳(A~Z, a~z), 숫자(0~9), 언더스코어(_), 하이픈(-), 한글(가-힣) 외에 문자가 포함되면 예외 발생")
+    @DisplayName("알파벳(A~Z, a~z), 숫자(0~9), 언더스코어(_), 하이픈(-), 한글(가-힣, 초성, 중성, 종성) 외에 문자가 포함되면 예외 발생")
     @CsvSource(value = {
             "특수 문자, !hello",
             "공백 문자, hel lo",
@@ -51,7 +71,7 @@ class NicknameTest {
                 .isInstanceOf(NicknameException.class)
                 .hasMessageContaining(INVALID_NICKNAME.getMessage());
     }
-    
+
     @ParameterizedTest
     @DisplayName("비속어 필터링")
     @ValueSource(strings = { "씨발", "개새끼"})

--- a/src/test/java/org/chzzk/howmeet/domain/common/model/NicknameTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/common/model/NicknameTest.java
@@ -1,11 +1,14 @@
 package org.chzzk.howmeet.domain.common.model;
 
+import org.chzzk.howmeet.domain.common.exception.NicknameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.chzzk.howmeet.common.util.DisplayFormat.DISPLAY_NAME_FORMAT;
+import static org.chzzk.howmeet.domain.common.exception.NicknameErrorCode.INVALID_NICKNAME;
 
 class NicknameTest {
     @ParameterizedTest(name = DISPLAY_NAME_FORMAT)
@@ -16,7 +19,8 @@ class NicknameTest {
     })
     public void invalidLength(final String displayName, final String value) throws Exception {
         assertThatThrownBy(() -> Nickname.from(value))
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(NicknameException.class)
+                .hasMessageContaining(INVALID_NICKNAME.getMessage());
     }
 
     @ParameterizedTest(name = DISPLAY_NAME_FORMAT)
@@ -32,7 +36,8 @@ class NicknameTest {
     })
     public void invalidCharacters(final String displayName, final String value) throws Exception {
         assertThatThrownBy(() -> Nickname.from(value))
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(NicknameException.class)
+                .hasMessageContaining(INVALID_NICKNAME.getMessage());
     }
 
     @ParameterizedTest(name = DISPLAY_NAME_FORMAT)
@@ -43,6 +48,16 @@ class NicknameTest {
     })
     public void invalidHyphenOrUnderscore(final String displayName, final String value) throws Exception {
         assertThatThrownBy(() -> Nickname.from(value))
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(NicknameException.class)
+                .hasMessageContaining(INVALID_NICKNAME.getMessage());
+    }
+    
+    @ParameterizedTest
+    @DisplayName("비속어 필터링")
+    @ValueSource(strings = { "씨발", "개새끼"})
+    public void badWordFiltering(final String value) throws Exception {
+        assertThatThrownBy(() -> Nickname.from(value))
+                .isInstanceOf(NicknameException.class)
+                .hasMessageContaining(INVALID_NICKNAME.getMessage());
     }
 }


### PR DESCRIPTION
## 작업 내용

- 비속어 필터링 라이브러리 (`badwordfiltering`) 의존성 추가
- `AuthenticationInterceptor` 예외 처리 커스텀
- `GuestAuthorityInterceptor` 예외 처리 커스텀
- `Nickname` 예외 처리 커스텀
- `PasswordValidator` 예외 처리 커스텀
- `GuestService` 예외 처리 커스텀
- `AuthException`, `AuthErrorCode` 추가
- `GuestException`, `GuestErrorCode` 추가
- `NicknameException`, `NicknameErrorCode` 추가
- 닉네임 검증 조건 수정
  - 한글 초성, 중성, 종성 허용

## 테스트
### Model
__NicknameTest__
<img width="569" alt="image" src="https://github.com/user-attachments/assets/7c8fe1be-a8e8-4d52-8cfc-7341cf976c23">


### Service
__GuestServiceTest__
<img width="554" alt="image" src="https://github.com/user-attachments/assets/06fca2cb-4fb9-4dfe-aa95-6d9e907f203a">

__PasswordValidatorTest__
<img width="555" alt="image" src="https://github.com/user-attachments/assets/f113389a-e8b2-49b4-9b46-12d58364b3ec">


### Controller
아직 전역 예외 처리가 구현되지 않아 X

## 기타 사항 (참고 자료, 문의 사항 등)
- 이해가지 않는 부분이 있다면 댓글 남겨주세요!
