### PR TITLE
[세팅] restdocs-swagger 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,18 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+buildscript {
+    ext {
+        restdocsApiSpecVersion = '0.16.2'
+    }
+}
+
 // spring boot 버전
 plugins {
-    id 'java'
     id 'org.springframework.boot' version '3.2.0'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'com.epages.restdocs-api-spec' version '0.18.4'
+    id 'org.hidetake.swagger.generator' version '2.18.2'
+    id 'java'
 }
 
 // group, version
@@ -17,6 +26,23 @@ java {
 
 repositories {
     mavenCentral()
+}
+
+openapi3 {
+    servers = [
+            { url = 'http://localhost:8080' },
+            { url = 'http://production-api-server-url.com' }
+    ]
+    title = 'Post Service API'
+    description = 'Post Service API description'
+    version = '1.0.0'
+    format = 'yaml'
+}
+
+swaggerSources {
+    sample {
+        setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
+    }
 }
 
 // 의존성
@@ -60,7 +86,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.4'
+    swaggerUI 'org.webjars:swagger-ui:4.11.1'
 }
+
 // Querydsl 빌드 옵션 (옵셔널)
 def generated = 'src/main/generated'
 
@@ -79,17 +107,24 @@ clean {
     delete file(generated)
 }
 
-test {
+tasks.named('test') {
     useJUnitPlatform()
+    exclude '**/GuestRepositoryTest.*'
 }
 
-openapi3 {
-    servers = [
-            { url = 'http://localhost:8080' },
-            { url = 'http://production-api-server-url.com' }
-    ]
-    title = 'Post Service API'
-    description = 'Post Service API description'
-    version = '1.0.0'
-    format = 'json'
+tasks.withType(GenerateSwaggerUI) {
+    dependsOn 'openapi3'
+}
+
+tasks.register('copySwaggerUI', Copy) {
+    dependsOn 'generateSwaggerUISample'
+
+    def generateSwaggerUISampleTask = tasks.named('generateSwaggerUISample', GenerateSwaggerUI).get()
+
+    from("${generateSwaggerUISampleTask.outputDir}")
+    into("${project.buildDir}/resources/main/static/docs")
+}
+
+tasks.withType(BootJar) {
+    dependsOn 'copySwaggerUI'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.0'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'com.epages.restdocs-api-spec' version '0.18.4'
 }
 
 // group, version
@@ -57,6 +58,8 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.4'
 }
 // Querydsl 빌드 옵션 (옵셔널)
 def generated = 'src/main/generated'
@@ -74,4 +77,19 @@ sourceSets {
 // gradle clean 시에 QClass 디렉토리 삭제
 clean {
     delete file(generated)
+}
+
+test {
+    useJUnitPlatform()
+}
+
+openapi3 {
+    servers = [
+            { url = 'http://localhost:8080' },
+            { url = 'http://production-api-server-url.com' }
+    ]
+    title = 'Post Service API'
+    description = 'Post Service API description'
+    version = '1.0.0'
+    format = 'json'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/src/test/java/org/chzzk/howmeet/RestDocsTest.java
+++ b/src/test/java/org/chzzk/howmeet/RestDocsTest.java
@@ -1,0 +1,27 @@
+package org.chzzk.howmeet;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsTest {
+
+    protected MockMvc mockMvc;
+    protected ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(initializeController())
+                .apply(documentationConfiguration(provider))
+                .build();
+    }
+
+    protected abstract Object initializeController();
+}

--- a/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestServiceTest.java
@@ -1,7 +1,9 @@
 package org.chzzk.howmeet.domain.temporary.auth.service;
 
+import org.chzzk.howmeet.RestDocsTest;
 import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
 import org.chzzk.howmeet.domain.common.model.EncodedPassword;
+import org.chzzk.howmeet.domain.temporary.auth.controller.GuestController;
 import org.chzzk.howmeet.domain.temporary.auth.dto.login.request.GuestLoginRequest;
 import org.chzzk.howmeet.domain.temporary.auth.dto.login.response.GuestLoginResponse;
 import org.chzzk.howmeet.domain.temporary.auth.dto.signup.request.GuestSignupRequest;
@@ -16,6 +18,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.http.MediaType;
 
 import java.util.Optional;
 
@@ -23,12 +27,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.chzzk.howmeet.fixture.GuestFixture.KIM;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.*;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
-class GuestServiceTest {
+@AutoConfigureRestDocs
+class GuestServiceTest extends RestDocsTest {
     @Mock
     GuestRepository guestRepository;
 
@@ -43,6 +52,11 @@ class GuestServiceTest {
 
     @InjectMocks
     GuestService guestService;
+
+    @Override
+    protected Object initializeController() {
+        return new GuestController(guestService);
+    }
 
     Guest guest = KIM.생성();
     EncodedPassword encodedPassword = guest.getPassword();
@@ -73,6 +87,24 @@ class GuestServiceTest {
 
         // then
         assertThat(actual).isEqualTo(expect);
+
+        // restdocs
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(guestLoginRequest)))
+                .andExpect(status().isOk())
+                .andDo(document("1회용 로그인",
+                        requestFields(
+                                fieldWithPath("guestScheduleId").description("게스트 일정 ID"),
+                                fieldWithPath("nickname").description("닉네임"),
+                                fieldWithPath("password").description("비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("accessToken").description("액세스 토큰"),
+                                fieldWithPath("guestId").type(NUMBER).description("게스트 id"),
+                                fieldWithPath("nickname").type(STRING).description("닉네임")
+                        )
+                ));
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
- restdocs-swagger 세팅

## 테스트
- restdocs 코드 작성(GuestServiceTest - 1회용 로그인에 샘플로 작업했습니다.)
![image](https://github.com/user-attachments/assets/70b25ffe-bebc-48df-8567-5ba953434da5)
- 오류가 없다면 gradle->document->openapi3 or ./gradlew openapi3 명령어 입력
![image](https://github.com/user-attachments/assets/e8c3855f-b8d5-40d1-9982-d33a92b9aa81)
- build/api-spec/openapi3.yaml 생성
![image](https://github.com/user-attachments/assets/7e2490f1-850d-4866-acab-004d4acb90bd)
- gradle build
![image](https://github.com/user-attachments/assets/3c275aed-52a0-4e78-8fa0-0ffb98a1b5a1)
- build/resources/main/static/dics/index.html 생성
![image](https://github.com/user-attachments/assets/1dabbb68-7144-4008-9acb-976810b9c792)
- 주소로 들어가면 swagger 화면이 보입니다!!
![스크린샷 2024-08-10 051515](https://github.com/user-attachments/assets/d464090a-f710-4a25-b064-4cb134b1be7f)


## 기타 사항 (참고 자료, 문의 사항 등)
- GuestRepositoryTest가 자꾸 오류가 나서 build.gradle에서 exclude 해뒀습니다. 
- 하면서 어려운 부분 있으면 연락주세요.
- 이걸 FE팀에 어떻게 공유를 해야할까요..?
