### PR TITLE
[기능 추가] 회원 기능 예외 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // Bean Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 // Querydsl 빌드 옵션 (옵셔널)
 def generated = 'src/main/generated'

--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthService.java
@@ -22,7 +22,6 @@ public class RegularAuthService {
     private final OAuthResultHandler oauthResultHandler;
     private final TokenProvider tokenProvider;
 
-    @Transactional
     public MemberLoginResponse login(final MemberLoginRequest memberLoginRequest) {
         final OAuthProvider oAuthProvider = inMemoryOAuthProviderRepository.findByProviderName(memberLoginRequest.providerName());
         final Member member = oAuthClient.getProfile(oAuthProvider, memberLoginRequest.code())

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/OAuthErrorResponseFactory.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/OAuthErrorResponseFactory.java
@@ -1,0 +1,53 @@
+package org.chzzk.howmeet.infra.oauth.exception;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.chzzk.howmeet.infra.oauth.exception.profile.response.OAuthProfileErrorResponse;
+import org.chzzk.howmeet.infra.oauth.exception.profile.response.detail.GoogleProfileErrorResponse;
+import org.chzzk.howmeet.infra.oauth.exception.profile.response.detail.KakaoProfileErrorResponse;
+import org.chzzk.howmeet.infra.oauth.exception.profile.response.detail.NaverProfileErrorResponse;
+import org.chzzk.howmeet.infra.oauth.exception.token.response.OAuthTokenIssueErrorResponse;
+import org.chzzk.howmeet.infra.oauth.exception.token.response.detail.GoogleTokenIssueErrorResponse;
+import org.chzzk.howmeet.infra.oauth.exception.token.response.detail.KakaoTokenIssueErrorResponse;
+import org.chzzk.howmeet.infra.oauth.exception.token.response.detail.NaverTokenIssueErrorResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class OAuthErrorResponseFactory {
+    private static final Map<String, ProviderErrorResponseConfig> errorResponseConfigMap = new HashMap<>();
+
+    static {
+        errorResponseConfigMap.put("kakao", new ProviderErrorResponseConfig(
+                KakaoProfileErrorResponse.class, KakaoTokenIssueErrorResponse.class)
+        );
+        errorResponseConfigMap.put("naver", new ProviderErrorResponseConfig(
+                NaverProfileErrorResponse.class, NaverTokenIssueErrorResponse.class)
+        );
+        errorResponseConfigMap.put("google", new ProviderErrorResponseConfig(
+                GoogleProfileErrorResponse.class, GoogleTokenIssueErrorResponse.class)
+        );
+    }
+
+    public static Class<? extends OAuthProfileErrorResponse> getProfileResponseClassFrom(final String providerName) {
+        return getProviderErrorResponseConfig(providerName).profileErrorResponseClass;
+    }
+
+    public static Class<? extends OAuthTokenIssueErrorResponse> getTokenIssueResponseClassFrom(final String providerName) {
+        return getProviderErrorResponseConfig(providerName).tokenIssueErrorResponseClass;
+    }
+
+    private static ProviderErrorResponseConfig getProviderErrorResponseConfig(final String providerName) {
+        final ProviderErrorResponseConfig config = errorResponseConfigMap.get(providerName);
+        if (config == null) {
+            throw new UnsupportedProviderException(providerName);
+        }
+        return config;
+    }
+
+    private record ProviderErrorResponseConfig(
+            Class<? extends OAuthProfileErrorResponse> profileErrorResponseClass,
+            Class<? extends OAuthTokenIssueErrorResponse> tokenIssueErrorResponseClass) {
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/UnsupportedProviderException.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/UnsupportedProviderException.java
@@ -1,0 +1,7 @@
+package org.chzzk.howmeet.infra.oauth.exception;
+
+public class UnsupportedProviderException extends RuntimeException {
+    public UnsupportedProviderException(final String providerName) {
+        super(providerName + " 소셜 로그인은 지원하지 않습니다.");
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/OAuthProfileException.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/OAuthProfileException.java
@@ -1,0 +1,12 @@
+package org.chzzk.howmeet.infra.oauth.exception.profile;
+
+import lombok.extern.slf4j.Slf4j;
+import org.chzzk.howmeet.infra.oauth.exception.profile.response.OAuthProfileErrorResponse;
+
+@Slf4j
+public class OAuthProfileException extends RuntimeException {
+    public OAuthProfileException(final OAuthProfileErrorResponse errorResponse) {
+        super(errorResponse.getMessage());
+        log.error("소셜 프로필 조회 실패. 에러 코드 : {}, 에러 메시지 : {}", errorResponse.getErrorCode(), errorResponse.getMessage());
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/response/OAuthProfileErrorResponse.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/response/OAuthProfileErrorResponse.java
@@ -1,0 +1,6 @@
+package org.chzzk.howmeet.infra.oauth.exception.profile.response;
+
+public interface OAuthProfileErrorResponse {
+    String getErrorCode();
+    String getMessage();
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/response/detail/GoogleProfileErrorResponse.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/response/detail/GoogleProfileErrorResponse.java
@@ -1,0 +1,18 @@
+package org.chzzk.howmeet.infra.oauth.exception.profile.response.detail;
+
+import org.chzzk.howmeet.infra.oauth.exception.profile.response.OAuthProfileErrorResponse;
+
+public record GoogleProfileErrorResponse(Error error) implements OAuthProfileErrorResponse {
+    @Override
+    public String getErrorCode() {
+        return error.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return error.message;
+    }
+
+    record Error(String code, String message, String status) {
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/response/detail/KakaoProfileErrorResponse.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/response/detail/KakaoProfileErrorResponse.java
@@ -1,0 +1,15 @@
+package org.chzzk.howmeet.infra.oauth.exception.profile.response.detail;
+
+import org.chzzk.howmeet.infra.oauth.exception.profile.response.OAuthProfileErrorResponse;
+
+public record KakaoProfileErrorResponse(Integer code, String msg) implements OAuthProfileErrorResponse {
+    @Override
+    public String getErrorCode() {
+        return code.toString();
+    }
+
+    @Override
+    public String getMessage() {
+        return msg;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/response/detail/NaverProfileErrorResponse.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/response/detail/NaverProfileErrorResponse.java
@@ -1,0 +1,15 @@
+package org.chzzk.howmeet.infra.oauth.exception.profile.response.detail;
+
+import org.chzzk.howmeet.infra.oauth.exception.profile.response.OAuthProfileErrorResponse;
+
+public record NaverProfileErrorResponse(String resultCode, String message) implements OAuthProfileErrorResponse {
+    @Override
+    public String getErrorCode() {
+        return resultCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/OAuthTokenIssueException.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/OAuthTokenIssueException.java
@@ -1,0 +1,20 @@
+package org.chzzk.howmeet.infra.oauth.exception.token;
+
+import lombok.extern.slf4j.Slf4j;
+import org.chzzk.howmeet.infra.oauth.exception.token.response.OAuthTokenIssueErrorResponse;
+
+@Slf4j
+public class OAuthTokenIssueException extends RuntimeException {
+    public OAuthTokenIssueException(final OAuthTokenIssueErrorResponse errorResponse) {
+        super(errorResponse.getMessage());
+        log.error("소셜 토큰 발급 실패. 에러 코드 : {}, 에러 메시지 : {}", errorResponse.getErrorCode(), errorResponse.getMessage());
+    }
+
+    private OAuthTokenIssueException(final String message) {
+        super(message);
+    }
+
+    public static OAuthTokenIssueException createWhenResponseIsNullOrEmpty() {
+        return new OAuthTokenIssueException("소셜 토큰 발급 API 호출은 성공했으나 응답값에 엑세스 토큰이 존재하지 않습니다. 네이버 소셜 로그인의 경우 인가 코드를 확인하세요.");
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/response/OAuthTokenIssueErrorResponse.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/response/OAuthTokenIssueErrorResponse.java
@@ -1,0 +1,6 @@
+package org.chzzk.howmeet.infra.oauth.exception.token.response;
+
+public interface OAuthTokenIssueErrorResponse {
+    String getErrorCode();
+    String getMessage();
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/response/detail/GoogleTokenIssueErrorResponse.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/response/detail/GoogleTokenIssueErrorResponse.java
@@ -1,0 +1,15 @@
+package org.chzzk.howmeet.infra.oauth.exception.token.response.detail;
+
+import org.chzzk.howmeet.infra.oauth.exception.token.response.OAuthTokenIssueErrorResponse;
+
+public record GoogleTokenIssueErrorResponse(String error, String error_description) implements OAuthTokenIssueErrorResponse {
+    @Override
+    public String getErrorCode() {
+        return error;
+    }
+
+    @Override
+    public String getMessage() {
+        return error_description;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/response/detail/KakaoTokenIssueErrorResponse.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/response/detail/KakaoTokenIssueErrorResponse.java
@@ -1,0 +1,15 @@
+package org.chzzk.howmeet.infra.oauth.exception.token.response.detail;
+
+import org.chzzk.howmeet.infra.oauth.exception.token.response.OAuthTokenIssueErrorResponse;
+
+public record KakaoTokenIssueErrorResponse(String error, String error_description) implements OAuthTokenIssueErrorResponse {
+    @Override
+    public String getErrorCode() {
+        return error;
+    }
+
+    @Override
+    public String getMessage() {
+        return error_description;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/response/detail/NaverTokenIssueErrorResponse.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/response/detail/NaverTokenIssueErrorResponse.java
@@ -1,0 +1,15 @@
+package org.chzzk.howmeet.infra.oauth.exception.token.response.detail;
+
+import org.chzzk.howmeet.infra.oauth.exception.token.response.OAuthTokenIssueErrorResponse;
+
+public record NaverTokenIssueErrorResponse(String error, String error_description) implements OAuthTokenIssueErrorResponse {
+    @Override
+    public String getErrorCode() {
+        return error;
+    }
+
+    @Override
+    public String getMessage() {
+        return error_description;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/repository/InMemoryOAuthProviderRepository.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/repository/InMemoryOAuthProviderRepository.java
@@ -1,6 +1,7 @@
 package org.chzzk.howmeet.infra.oauth.repository;
 
 import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.infra.oauth.exception.UnsupportedProviderException;
 import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
 
 import java.util.Map;
@@ -10,6 +11,9 @@ public class InMemoryOAuthProviderRepository {
     private final Map<String, OAuthProvider> providers;
 
     public OAuthProvider findByProviderName(String providerName) {
+        if (!providers.containsKey(providerName)) {
+            throw new UnsupportedProviderException(providerName);
+        }
         return providers.get(providerName);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/service/OAuthClient.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/service/OAuthClient.java
@@ -3,9 +3,12 @@ package org.chzzk.howmeet.infra.oauth.service;
 import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.infra.oauth.dto.token.request.OAuthTokenRequest;
 import org.chzzk.howmeet.infra.oauth.dto.token.response.OAuthTokenResponse;
+import org.chzzk.howmeet.infra.oauth.exception.token.OAuthTokenIssueException;
 import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
 import org.chzzk.howmeet.infra.oauth.util.MultiValueMapConverter;
+import org.h2.util.StringUtils;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
@@ -14,18 +17,26 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @Service
 public class OAuthClient {
     private final MultiValueMapConverter multiValueMapConverter;
     private final OAuthTimeoutHandler oAuthTimeoutHandler;
+    private final ProfileFailHandler profileFailHandler;
+    private final TokenIssueFailHandler tokenIssueFailHandler;
     private final WebClient webClient;
-
 
     public Mono<Map<String, Object>> getProfile(final OAuthProvider provider, final String code) {
         return getTokenApplyRetryAndTimeout(provider, code)
-                .flatMap(response -> getProfileApplyRetryAndTimeout(provider, response));
+                .flatMap(response -> {
+                    if (failedTokenIssue(response)) {
+                        return Mono.error(OAuthTokenIssueException.createWhenResponseIsNullOrEmpty());
+                    }
+
+                    return getProfileApplyRetryAndTimeout(provider, response);
+                });
     }
 
     private Mono<Map<String, Object>> getProfileFromToken(final OAuthProvider provider, final String socialAccessToken) {
@@ -34,6 +45,8 @@ public class OAuthClient {
                 .headers(header -> header.setBearerAuth(socialAccessToken))
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> profileFailHandler.handle4xxError(clientResponse, provider))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> profileFailHandler.handle5xxError(clientResponse, provider))
                 .bodyToMono(new ParameterizedTypeReference<>() {
                 });
     }
@@ -44,7 +57,13 @@ public class OAuthClient {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(BodyInserters.fromFormData(getIssueTokenParams(provider, code)))
                 .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> tokenIssueFailHandler.handle4xxError(clientResponse, provider))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> tokenIssueFailHandler.handle5xxError(clientResponse, provider))
                 .bodyToMono(OAuthTokenResponse.class);
+    }
+
+    private boolean failedTokenIssue(final OAuthTokenResponse oAuthTokenResponse) {
+        return Objects.isNull(oAuthTokenResponse) || StringUtils.isNullOrEmpty(oAuthTokenResponse.access_token());
     }
 
     private Mono<OAuthTokenResponse> getTokenApplyRetryAndTimeout(final OAuthProvider provider, final String code) {

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/service/OAuthClient.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/service/OAuthClient.java
@@ -1,10 +1,10 @@
 package org.chzzk.howmeet.infra.oauth.service;
 
-import lombok.RequiredArgsConstructor;
-import org.chzzk.howmeet.infra.oauth.util.MultiValueMapConverter;
 import org.chzzk.howmeet.infra.oauth.dto.token.request.OAuthTokenRequest;
 import org.chzzk.howmeet.infra.oauth.dto.token.response.OAuthTokenResponse;
 import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
+import org.chzzk.howmeet.infra.oauth.util.MultiValueMapConverter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -12,14 +12,28 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
-@RequiredArgsConstructor
 @Service
 public class OAuthClient {
     private final MultiValueMapConverter multiValueMapConverter;
     private final WebClient webClient;
+    private final int timeout;
+    private final int maxRetry;
+
+    public OAuthClient(final MultiValueMapConverter multiValueMapConverter,
+                       final WebClient webClient,
+                       @Value("${oauth.timeout}") final int timeout,
+                       @Value("${oauth.max-retry}") final int maxRetry) {
+        this.multiValueMapConverter = multiValueMapConverter;
+        this.webClient = webClient;
+        this.timeout = timeout;
+        this.maxRetry = maxRetry;
+    }
 
     public Mono<Map<String, Object>> getProfile(final OAuthProvider provider, final String code) {
         return issueToken(provider, code)
@@ -32,8 +46,11 @@ public class OAuthClient {
                 .headers(header -> header.setBearerAuth(socialAccessToken))
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<>() {
-                });
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+                })
+                .timeout(Duration.ofMillis(timeout))
+                .retryWhen(Retry.max(maxRetry).filter(this::isRetryable))
+                .onErrorMap(TimeoutException.class, e -> new IllegalStateException("요청 시간이 초과되었습니다.", e));
     }
 
     private Mono<OAuthTokenResponse> issueToken(final OAuthProvider provider, final String code) {
@@ -42,10 +59,17 @@ public class OAuthClient {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(BodyInserters.fromFormData(getIssueTokenParams(provider, code)))
                 .retrieve()
-                .bodyToMono(OAuthTokenResponse.class);
+                .bodyToMono(OAuthTokenResponse.class)
+                .timeout(Duration.ofMillis(timeout))
+                .retryWhen(Retry.max(maxRetry).filter(this::isRetryable))
+                .onErrorMap(TimeoutException.class, e -> new IllegalStateException("요청 시간이 초과되었습니다.", e));
     }
 
     private MultiValueMap<String, String> getIssueTokenParams(final OAuthProvider provider, final String code) {
         return multiValueMapConverter.convertFrom(OAuthTokenRequest.of(provider, code));
+    }
+
+    private boolean isRetryable(Throwable ex) {
+        return (ex instanceof IllegalStateException) || (ex instanceof TimeoutException);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/service/OAuthTimeoutHandler.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/service/OAuthTimeoutHandler.java
@@ -1,0 +1,33 @@
+package org.chzzk.howmeet.infra.oauth.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+@Component
+public class OAuthTimeoutHandler {
+    private final int timeout;
+    private final int maxRetry;
+
+    public OAuthTimeoutHandler(@Value("${oauth.timeout}") final int timeout,
+                               @Value("${oauth.max-retry}") final int maxRetry) {
+        this.timeout = timeout;
+        this.maxRetry = maxRetry;
+    }
+
+    public <T> Mono<T> handle(final Supplier<Mono<T>> request) {
+        return request.get()
+                .timeout(Duration.ofMillis(timeout))
+                .retryWhen(Retry.max(maxRetry).filter(this::isRetryable))
+                .onErrorMap(TimeoutException.class, e -> new IllegalStateException("요청 시간이 초과되었습니다.", e));
+    }
+
+    private boolean isRetryable(Throwable ex) {
+        return (ex instanceof IllegalStateException) || (ex instanceof TimeoutException);
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/service/ProfileFailHandler.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/service/ProfileFailHandler.java
@@ -1,0 +1,25 @@
+package org.chzzk.howmeet.infra.oauth.service;
+
+import org.chzzk.howmeet.infra.oauth.exception.OAuthErrorResponseFactory;
+import org.chzzk.howmeet.infra.oauth.exception.profile.OAuthProfileException;
+import org.chzzk.howmeet.infra.oauth.exception.profile.response.OAuthProfileErrorResponse;
+import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+public class ProfileFailHandler {
+    public Mono<OAuthProfileException> handle4xxError(final ClientResponse clientResponse,
+                                                      final OAuthProvider oAuthProvider) {
+        return clientResponse.bodyToMono(OAuthErrorResponseFactory.getProfileResponseClassFrom(oAuthProvider.name()))
+                .map(OAuthProfileException::new);
+    }
+
+    public Mono<IllegalStateException> handle5xxError(final ClientResponse clientResponse,
+                                                      final OAuthProvider oAuthProvider) {
+        return clientResponse.bodyToMono(OAuthErrorResponseFactory.getProfileResponseClassFrom(oAuthProvider.name()))
+                .map(OAuthProfileErrorResponse::getMessage)
+                .map(IllegalStateException::new);
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/service/TokenIssueFailHandler.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/service/TokenIssueFailHandler.java
@@ -1,0 +1,25 @@
+package org.chzzk.howmeet.infra.oauth.service;
+
+import org.chzzk.howmeet.infra.oauth.exception.OAuthErrorResponseFactory;
+import org.chzzk.howmeet.infra.oauth.exception.token.OAuthTokenIssueException;
+import org.chzzk.howmeet.infra.oauth.exception.token.response.OAuthTokenIssueErrorResponse;
+import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+public class TokenIssueFailHandler {
+    public Mono<OAuthTokenIssueException> handle4xxError(final ClientResponse clientResponse,
+                                                         final OAuthProvider oAuthProvider) {
+        return clientResponse.bodyToMono(OAuthErrorResponseFactory.getTokenIssueResponseClassFrom(oAuthProvider.name()))
+                .map(OAuthTokenIssueException::new);
+    }
+
+    public Mono<IllegalStateException> handle5xxError(final ClientResponse clientResponse,
+                                                      final OAuthProvider oAuthProvider) {
+        return clientResponse.bodyToMono(OAuthErrorResponseFactory.getTokenIssueResponseClassFrom(oAuthProvider.name()))
+                .map(OAuthTokenIssueErrorResponse::getMessage)
+                .map(IllegalStateException::new);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,8 @@ spring:
     import:
       - classpath:/yaml/application-auth.yml
       - classpath:/yaml/application-db.yml
+      - classpath:/yaml/application-oauth.yml
   profiles:
     group:
-      develop: auth, db
+      develop: auth, db, oauth
     active: develop


### PR DESCRIPTION
## 작업 내용

- `WebClient` 타임아웃 예외 핸들링
- 소셜 토큰 발급 예외 핸들링
- 프로필 조회 예외 핸들링
- 회원 로그인시 소셜 이름 검증 로직 추가
- Bean Validation 의존성 추가

## 테스트
-  WebClient 예외 처리 테스트라 로그로 확인했습니다. 추후, 전역 예외 처리가 구현되면 테스트 결과를 올리겠습니다!

## 기타 사항 (참고 자료, 문의 사항 등)
- 외부 API 요청의 경우 예외 메시지를 열거체로 처리하기 힘들어 실패 시 응답을 로깅 후 응답에 담긴 메시지를 프론트에 전달하는 식으로 구현했습니다. (`OAuthXXXException` 참고)
- 기본적으로 WebClient 예외 처리는 `onStatus()` 를 통해 처리하나, 네이버의 경우 소셜 토큰 발급 실패시 상태 코드가 200으로 와서 핸들링하기 힘들었습니다. 따라서, 소셜 토큰 발급 후 프로필을 조회하는 과정에서 핸들링을 하고 있습니다! (`OAuthClient` 32 ~ 39번째 코드 참고)
- 정리글 : [소셜 로그인 회고록](https://velog.io/@kmw89891/소셜-로그인-Feat.-DDD-예외-처리)