### PR TITLE
[기능 추가] 간단 회원 정보 조회

### DIFF
--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/dto/login/response/MemberLoginResponse.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/dto/login/response/MemberLoginResponse.java
@@ -1,6 +1,6 @@
 package org.chzzk.howmeet.domain.regular.auth.dto.login.response;
 
-import org.chzzk.howmeet.domain.regular.auth.entity.Member;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
 
 public record MemberLoginResponse(String accessToken, Long memberId, String nickname) {
     public static MemberLoginResponse of(final String accessToken, final Member member) {

--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/OAuthResultHandler.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/OAuthResultHandler.java
@@ -2,7 +2,7 @@ package org.chzzk.howmeet.domain.regular.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.domain.regular.auth.entity.Member;
-import org.chzzk.howmeet.domain.regular.auth.repository.MemberRepository;
+import org.chzzk.howmeet.domain.regular.member.repository.MemberRepository;
 import org.chzzk.howmeet.infra.oauth.model.profile.OAuthProfile;
 import org.chzzk.howmeet.infra.oauth.model.profile.OAuthProfileFactory;
 import org.springframework.stereotype.Service;

--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/OAuthResultHandler.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/OAuthResultHandler.java
@@ -1,7 +1,7 @@
 package org.chzzk.howmeet.domain.regular.auth.service;
 
 import lombok.RequiredArgsConstructor;
-import org.chzzk.howmeet.domain.regular.auth.entity.Member;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
 import org.chzzk.howmeet.domain.regular.member.repository.MemberRepository;
 import org.chzzk.howmeet.infra.oauth.model.profile.OAuthProfile;
 import org.chzzk.howmeet.infra.oauth.model.profile.OAuthProfileFactory;

--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
 import org.chzzk.howmeet.domain.regular.auth.dto.login.request.MemberLoginRequest;
 import org.chzzk.howmeet.domain.regular.auth.dto.login.response.MemberLoginResponse;
-import org.chzzk.howmeet.domain.regular.auth.entity.Member;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
 import org.chzzk.howmeet.global.util.TokenProvider;
 import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
 import org.chzzk.howmeet.infra.oauth.repository.InMemoryOAuthProviderRepository;

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/controller/MemberController.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/controller/MemberController.java
@@ -1,0 +1,24 @@
+package org.chzzk.howmeet.domain.regular.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.common.auth.annotation.Authenticated;
+import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
+import org.chzzk.howmeet.domain.regular.auth.annotation.RegularUser;
+import org.chzzk.howmeet.domain.regular.member.service.MemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/member")
+@RestController
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping("/summary")
+    @RegularUser
+    public ResponseEntity<?> getSummary(final @Authenticated AuthPrincipal authPrincipal) {
+        return ResponseEntity.ok(memberService.getSummary(authPrincipal));
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/dto/summary/dto/MemberSummaryDto.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/dto/summary/dto/MemberSummaryDto.java
@@ -1,0 +1,8 @@
+package org.chzzk.howmeet.domain.regular.member.dto.summary.dto;
+
+import org.chzzk.howmeet.domain.common.model.Nickname;
+
+public record MemberSummaryDto(Long id, Nickname nickname) {
+    public MemberSummaryDto {
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/dto/summary/response/MemberSummaryResponse.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/dto/summary/response/MemberSummaryResponse.java
@@ -1,0 +1,9 @@
+package org.chzzk.howmeet.domain.regular.member.dto.summary.response;
+
+import org.chzzk.howmeet.domain.regular.member.dto.summary.dto.MemberSummaryDto;
+
+public record MemberSummaryResponse(Long id, String nickname) {
+    public static MemberSummaryResponse from(final MemberSummaryDto memberSummaryDto) {
+        return new MemberSummaryResponse(memberSummaryDto.id(), memberSummaryDto.nickname().getValue());
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/entity/Member.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/entity/Member.java
@@ -1,4 +1,4 @@
-package org.chzzk.howmeet.domain.regular.auth.entity;
+package org.chzzk.howmeet.domain.regular.member.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/exception/MemberErrorCode.java
@@ -1,0 +1,17 @@
+package org.chzzk.howmeet.domain.regular.member.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MemberErrorCode {
+    MEMBER_NOT_FOUND("회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus status;
+
+    MemberErrorCode(final String message, final HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/exception/MemberException.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/exception/MemberException.java
@@ -1,0 +1,10 @@
+package org.chzzk.howmeet.domain.regular.member.exception;
+
+public class MemberException extends RuntimeException {
+    private final MemberErrorCode errorCode;
+
+    public MemberException(final MemberErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberRepository.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberRepository.java
@@ -1,4 +1,4 @@
-package org.chzzk.howmeet.domain.regular.auth.repository;
+package org.chzzk.howmeet.domain.regular.member.repository;
 
 import org.chzzk.howmeet.domain.regular.auth.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberRepository.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberRepository.java
@@ -1,10 +1,18 @@
 package org.chzzk.howmeet.domain.regular.member.repository;
 
+import org.chzzk.howmeet.domain.regular.member.dto.summary.dto.MemberSummaryDto;
 import org.chzzk.howmeet.domain.regular.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialId(final String socialId);
+
+    @Query("SELECT NEW org.chzzk.howmeet.domain.regular.member.dto.summary.dto.MemberSummaryDto(m.id, m.nickname) " +
+            "FROM Member m " +
+            "WHERE m.id =:id")
+    Optional<MemberSummaryDto> findSummaryById(@Param("id") final Long id);
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberRepository.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberRepository.java
@@ -1,6 +1,6 @@
 package org.chzzk.howmeet.domain.regular.member.repository;
 
-import org.chzzk.howmeet.domain.regular.auth.entity.Member;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberService.java
@@ -1,0 +1,27 @@
+package org.chzzk.howmeet.domain.regular.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
+import org.chzzk.howmeet.domain.regular.member.dto.summary.dto.MemberSummaryDto;
+import org.chzzk.howmeet.domain.regular.member.dto.summary.response.MemberSummaryResponse;
+import org.chzzk.howmeet.domain.regular.member.exception.MemberException;
+import org.chzzk.howmeet.domain.regular.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+import static org.chzzk.howmeet.domain.regular.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public MemberSummaryResponse getSummary(final AuthPrincipal authPrincipal) {
+        final MemberSummaryDto memberSummaryDto = findMemberSummaryById(authPrincipal.id());
+        return MemberSummaryResponse.from(memberSummaryDto);
+    }
+
+    private MemberSummaryDto findMemberSummaryById(final Long memberId) {
+        return memberRepository.findSummaryById(memberId)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/record/entity/MemberScheduleRecord.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/record/entity/MemberScheduleRecord.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.chzzk.howmeet.domain.common.entity.BaseEntity;
 import org.chzzk.howmeet.domain.common.embedded.date.impl.RecordDate;
-import org.chzzk.howmeet.domain.regular.auth.entity.Member;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
 import org.chzzk.howmeet.domain.regular.schedule.entity.MemberSchedule;
 
 @Entity

--- a/src/main/java/org/chzzk/howmeet/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/org/chzzk/howmeet/global/interceptor/AuthenticationInterceptor.java
@@ -8,7 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.chzzk.howmeet.domain.common.auth.exception.AuthException;
 import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
-import org.chzzk.howmeet.domain.regular.auth.repository.MemberRepository;
+import org.chzzk.howmeet.domain.regular.member.repository.MemberRepository;
 import org.chzzk.howmeet.domain.temporary.auth.repository.GuestRepository;
 import org.chzzk.howmeet.global.util.TokenProvider;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/model/profile/OAuthProfile.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/model/profile/OAuthProfile.java
@@ -1,6 +1,6 @@
 package org.chzzk.howmeet.infra.oauth.model.profile;
 
-import org.chzzk.howmeet.domain.regular.auth.entity.Member;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
 
 import java.util.Map;
 

--- a/src/test/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthServiceTest.java
@@ -3,7 +3,7 @@ package org.chzzk.howmeet.domain.regular.auth.service;
 import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
 import org.chzzk.howmeet.domain.regular.auth.dto.login.request.MemberLoginRequest;
 import org.chzzk.howmeet.domain.regular.auth.dto.login.response.MemberLoginResponse;
-import org.chzzk.howmeet.domain.regular.auth.entity.Member;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
 import org.chzzk.howmeet.global.util.TokenProvider;
 import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
 import org.chzzk.howmeet.infra.oauth.repository.InMemoryOAuthProviderRepository;

--- a/src/test/java/org/chzzk/howmeet/domain/regular/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,35 @@
+package org.chzzk.howmeet.domain.regular.member.repository;
+
+import org.chzzk.howmeet.domain.regular.member.dto.summary.dto.MemberSummaryDto;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
+import org.chzzk.howmeet.global.config.RepositoryTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+class MemberRepositoryTest {
+    @Autowired
+    MemberRepository memberRepository;
+
+    @ParameterizedTest
+    @DisplayName("소셜 ID로 정기 회원 조회")
+    @ValueSource(strings = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"})
+    public void findBySocialId(final String socialId) throws Exception {
+        final Member member = memberRepository.findBySocialId(socialId)
+                .get();
+        assertThat(member.getSocialId()).isEqualTo(socialId);
+    }
+
+    @ParameterizedTest
+    @DisplayName("ID로 간단 회원 정보 조회")
+    @ValueSource(longs = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+    public void findSummaryById(final Long id) throws Exception {
+        final MemberSummaryDto memberSummaryDto = memberRepository.findSummaryById(id)
+                .get();
+        assertThat(memberSummaryDto.id()).isEqualTo(id);
+    }
+}

--- a/src/test/java/org/chzzk/howmeet/domain/regular/member/service/MemberServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/member/service/MemberServiceTest.java
@@ -1,0 +1,65 @@
+package org.chzzk.howmeet.domain.regular.member.service;
+
+
+import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
+import org.chzzk.howmeet.domain.regular.member.dto.summary.dto.MemberSummaryDto;
+import org.chzzk.howmeet.domain.regular.member.dto.summary.response.MemberSummaryResponse;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
+import org.chzzk.howmeet.domain.regular.member.exception.MemberException;
+import org.chzzk.howmeet.domain.regular.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.chzzk.howmeet.domain.regular.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
+import static org.chzzk.howmeet.fixture.MemberFixture.KIM;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+    @Mock
+    MemberRepository memberRepository;
+
+    @InjectMocks
+    MemberService memberService;
+
+    Member member = KIM.생성();
+
+    @Test
+    @DisplayName("토큰 페이로드로 간단 회원 정보 조회")
+    public void getSummary() throws Exception {
+        // given
+        final AuthPrincipal authPrincipal = AuthPrincipal.from(member);
+        final MemberSummaryDto memberSummaryDto = new MemberSummaryDto(member.getId(), member.getNickname());
+        final MemberSummaryResponse expect = MemberSummaryResponse.from(memberSummaryDto);
+
+        // when
+        doReturn(Optional.of(memberSummaryDto)).when(memberRepository).findSummaryById(authPrincipal.id());
+        final MemberSummaryResponse actual = memberService.getSummary(authPrincipal);
+
+        // then
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    @DisplayName("토큰 페이로드에 해당하는 회원이 없는 경우 예외 발생")
+    public void getSummaryWhenNotFound() throws Exception {
+        // given
+        final AuthPrincipal authPrincipal = AuthPrincipal.from(member);
+
+        // when
+        doReturn(Optional.empty()).when(memberRepository).findSummaryById(authPrincipal.id());
+
+        // then
+        assertThatThrownBy(() -> memberService.getSummary(authPrincipal))
+                .isInstanceOf(MemberException.class)
+                .hasMessageContaining(MEMBER_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestServiceTest.java
@@ -2,7 +2,6 @@ package org.chzzk.howmeet.domain.temporary.auth.service;
 
 import org.chzzk.howmeet.RestDocsTest;
 import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
-import org.chzzk.howmeet.domain.common.exception.NicknameException;
 import org.chzzk.howmeet.domain.common.model.EncodedPassword;
 import org.chzzk.howmeet.domain.temporary.auth.controller.GuestController;
 import org.chzzk.howmeet.domain.temporary.auth.dto.login.request.GuestLoginRequest;
@@ -25,20 +24,23 @@ import org.springframework.http.MediaType;
 
 import java.util.Optional;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.chzzk.howmeet.domain.common.exception.NicknameErrorCode.INVALID_NICKNAME;
 import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.GUEST_ALREADY_EXIST;
 import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.GUEST_NOT_FOUND;
 import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.INVALID_PASSWORD;
 import static org.chzzk.howmeet.fixture.GuestFixture.KIM;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/org/chzzk/howmeet/fixture/MemberFixture.java
+++ b/src/test/java/org/chzzk/howmeet/fixture/MemberFixture.java
@@ -1,6 +1,6 @@
 package org.chzzk.howmeet.fixture;
 
-import org.chzzk.howmeet.domain.regular.auth.entity.Member;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
 
 public enum MemberFixture {
     KIM("김민우", "프로필 사진 URL", "123");

--- a/src/test/resources/db/dummy/insert_member.sql
+++ b/src/test/resources/db/dummy/insert_member.sql
@@ -1,15 +1,15 @@
 -- Member 데이터 삽입
 INSERT INTO member (`id`, `nickname`, `profile_image`, `social_id`)
-VALUES (1, 'member1', 'image1.png', 'member1@gmail.com'),
-       (2, 'member2', 'image2.png', 'member2@gmail.com'),
-       (3, 'member3', 'image3.png', 'member3@gmail.com'),
-       (4, 'member4', 'image4.png', 'member4@gmail.com'),
-       (5, 'member5', 'image5.png', 'member5@gmail.com'),
-       (6, 'member6', 'image6.png', 'member6@gmail.com'),
-       (7, 'member7', 'image7.png', 'member7@gmail.com'),
-       (8, 'member8', 'image8.png', 'member8@gmail.com'),
-       (9, 'member9', 'image9.png', 'member9@gmail.com'),
-       (10, 'member10', 'image10.png', 'member10@gmail.com');
+VALUES (1, 'member1', 'image1.png', '1'),
+       (2, 'member2', 'image2.png', '2'),
+       (3, 'member3', 'image3.png', '3'),
+       (4, 'member4', 'image4.png', '4'),
+       (5, 'member5', 'image5.png', '5'),
+       (6, 'member6', 'image6.png', '6'),
+       (7, 'member7', 'image7.png', '7'),
+       (8, 'member8', 'image8.png', '8'),
+       (9, 'member9', 'image9.png', '9'),
+       (10, 'member10', 'image10.png', '10');
 
 -- Room 데이터 삽입
 INSERT INTO room (`id`, `name`, `description`)


### PR DESCRIPTION
## 작업 내용
- 토큰에 해당하는 회원의 닉네임 제공 API(기능명세서 ID- 46) 추가
- `MemberController` 추가
- `MemberService` 추가
- `MemberException` 추가
- `MemberErrorCode` 추가

## 테스트
### Repository
<img width="556" alt="image" src="https://github.com/user-attachments/assets/32e7e04f-a004-4d27-8e87-68e38d43817d">

### Service
<img width="554" alt="image" src="https://github.com/user-attachments/assets/8ee4c33d-df82-41d2-988c-525b617c7b82">

### Controller
<img width="1256" alt="image" src="https://github.com/user-attachments/assets/405da3be-bffe-4d05-ad64-1a65118b5b0d">


## 기타 사항 (참고 자료, 문의 사항 등)
마이 페이지나 간단 회원 정보와 같은 기능은 기존 `RegularAuthController`, `RegularAuthService`  에 작성하는게 맞지 않다 판단하여 분리했습니다! 
- `RegularAuth` : 토큰 발급, 삭제, 재발급
- `Member` : 회원 정보 조회 및 수정