### PR TITLE
[버그 수정] 비회원 가입 검증

### DIFF
--- a/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/repository/GSQueryDSL.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/repository/GSQueryDSL.java
@@ -1,0 +1,5 @@
+package org.chzzk.howmeet.domain.temporary.schedule.repository;
+
+public interface GSQueryDSL {
+    boolean existsByGuestScheduleId(final Long guestScheduleId);
+}

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/repository/GSQueryDSLImpl.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/repository/GSQueryDSLImpl.java
@@ -1,0 +1,21 @@
+package org.chzzk.howmeet.domain.temporary.schedule.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static org.chzzk.howmeet.domain.temporary.schedule.entity.QGuestSchedule.guestSchedule;
+
+@RequiredArgsConstructor
+public class GSQueryDSLImpl implements GSQueryDSL {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByGuestScheduleId(final Long guestScheduleId) {
+        final Integer fetchFirst = queryFactory.selectOne()
+                .from(guestSchedule)
+                .where(guestSchedule.id.eq(guestScheduleId))
+                .fetchFirst();
+
+        return fetchFirst != null;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/repository/GSRepository.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/repository/GSRepository.java
@@ -3,5 +3,5 @@ package org.chzzk.howmeet.domain.temporary.schedule.repository;
 import org.chzzk.howmeet.domain.temporary.schedule.entity.GuestSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface GSRepository extends JpaRepository<GuestSchedule, Long> {
+public interface GSRepository extends JpaRepository<GuestSchedule, Long>, GSQueryDSL {
 }

--- a/src/test/java/org/chzzk/howmeet/domain/temporary/schedule/repository/GSRepositoryTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/temporary/schedule/repository/GSRepositoryTest.java
@@ -1,0 +1,22 @@
+package org.chzzk.howmeet.domain.temporary.schedule.repository;
+
+import org.chzzk.howmeet.global.config.RepositoryTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+class GSRepositoryTest {
+    @Autowired
+    GSRepository gsRepository;
+
+    @ParameterizedTest
+    @DisplayName("ID로 비회원 일정 확인")
+    @ValueSource(longs = {1L, 2L, 3L})
+    public void existsByGuestScheduleId(final Long guestScheduleId) throws Exception {
+        assertThat(gsRepository.existsByGuestScheduleId(guestScheduleId)).isTrue();
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 비회원 가입시 `guestScheduleId` 에 해당하는 일정이 없음에도 가입되던 문제 해결

## 테스트
### Repository
<img width="552" alt="image" src="https://github.com/user-attachments/assets/e297a511-c62d-4383-aa77-f890f17ca746">

### Controller
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/f2438d58-26f4-4dfe-926b-9f9cd73ed95d">
<img width="1238" alt="image" src="https://github.com/user-attachments/assets/020c126e-df97-4874-8de8-28e701696dae">


## 기타 사항 (참고 자료, 문의 사항 등)
비회원 가입 시 요청 파라미터는 다음과 같습니다.
- 일정 ID
- 닉네임
- 비밀번호

이 때, 다음 2가지를 검증합니다.
- 일정 ID가 유효한지
- 해당 일정 ID에 중복 닉네임이 있는지

이를 하나의 SQL로 구현하려다 가독성을 위해 2개 SQL로 구현했습니다. (`GuestService.signUp()` 참고)
이로 인해 PHAMTOM READ 가 발생할 수 있는지 의견 부탁드립니다!