### PR TITLE
[기능 수정] OAuth 프로필 조회 반환 타입

### DIFF
--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/OAuthResultHandler.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/OAuthResultHandler.java
@@ -4,11 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.domain.regular.auth.entity.Member;
 import org.chzzk.howmeet.domain.regular.auth.repository.MemberRepository;
 import org.chzzk.howmeet.infra.oauth.model.profile.OAuthProfile;
-import org.chzzk.howmeet.infra.oauth.model.profile.OAuthProfileFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Map;
 
 @RequiredArgsConstructor
 @Service
@@ -17,8 +14,7 @@ public class OAuthResultHandler {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Member saveOrGet(final Map<String, Object> attributes, final String providerName) {
-        final OAuthProfile oAuthProfile = OAuthProfileFactory.of(attributes, providerName);
+    public Member saveOrGet(final OAuthProfile oAuthProfile) {
         return memberRepository.findBySocialId(oAuthProfile.getSocialId())
                         .orElseGet(() -> memberRepository.save(oAuthProfile.toEntity()));
     }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthService.java
@@ -26,7 +26,7 @@ public class RegularAuthService {
         final OAuthProvider oAuthProvider = inMemoryOAuthProviderRepository.findByProviderName(memberLoginRequest.providerName());
         final Member member = oAuthClient.getProfile(oAuthProvider, memberLoginRequest.code())
                 .publishOn(Schedulers.boundedElastic())
-                .map(attributes -> oauthResultHandler.saveOrGet(attributes, memberLoginRequest.providerName()))
+                .map(oauthResultHandler::saveOrGet)
                 .block();
 
         final AuthPrincipal authPrincipal = AuthPrincipal.from(member);

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/UnsupportedProviderException.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/UnsupportedProviderException.java
@@ -1,7 +1,13 @@
 package org.chzzk.howmeet.infra.oauth.exception;
 
+import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
+
 public class UnsupportedProviderException extends RuntimeException {
     public UnsupportedProviderException(final String providerName) {
         super(providerName + " 소셜 로그인은 지원하지 않습니다.");
+    }
+
+    public UnsupportedProviderException(final OAuthProvider oAuthProvider) {
+        super(oAuthProvider.name());
     }
 }

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/model/profile/OAuthProfileFactory.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/model/profile/OAuthProfileFactory.java
@@ -1,6 +1,8 @@
 package org.chzzk.howmeet.infra.oauth.model.profile;
 
 
+import org.chzzk.howmeet.infra.oauth.exception.UnsupportedProviderException;
+import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
 import org.chzzk.howmeet.infra.oauth.model.profile.detail.GoogleProfile;
 import org.chzzk.howmeet.infra.oauth.model.profile.detail.KakaoProfile;
 import org.chzzk.howmeet.infra.oauth.model.profile.detail.NaverProfile;
@@ -24,9 +26,9 @@ public enum OAuthProfileFactory {
     }
 
     public static OAuthProfile of(final Map<String, Object> attributes,
-                                  final String providerName) {
+                                  final OAuthProvider oAuthProvider) {
         return Arrays.stream(values())
-                .filter(value -> value.socialName.equals(providerName.toLowerCase()))
+                .filter(value -> value.socialName.equals(oAuthProvider.name().toLowerCase()))
                 .findAny()
                 .map(value -> value.mapper.apply(attributes))
                 .orElseThrow(() -> new IllegalArgumentException());

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/model/profile/OAuthProfileFactory.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/model/profile/OAuthProfileFactory.java
@@ -31,6 +31,6 @@ public enum OAuthProfileFactory {
                 .filter(value -> value.socialName.equals(oAuthProvider.name().toLowerCase()))
                 .findAny()
                 .map(value -> value.mapper.apply(attributes))
-                .orElseThrow(() -> new IllegalArgumentException());
+                .orElseThrow(() -> new UnsupportedProviderException(oAuthProvider));
     }
 }

--- a/src/test/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthServiceTest.java
@@ -6,6 +6,8 @@ import org.chzzk.howmeet.domain.regular.auth.dto.login.response.MemberLoginRespo
 import org.chzzk.howmeet.domain.regular.auth.entity.Member;
 import org.chzzk.howmeet.global.util.TokenProvider;
 import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
+import org.chzzk.howmeet.infra.oauth.model.profile.OAuthProfile;
+import org.chzzk.howmeet.infra.oauth.model.profile.OAuthProfileFactory;
 import org.chzzk.howmeet.infra.oauth.repository.InMemoryOAuthProviderRepository;
 import org.chzzk.howmeet.infra.oauth.service.OAuthClient;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +21,6 @@ import org.springframework.http.HttpMethod;
 import reactor.core.publisher.Mono;
 
 import java.util.Collections;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,8 +49,6 @@ class RegularAuthServiceTest {
     String code = "authenticate_code";
     String accessToken = "accessToken";
     MemberLoginResponse memberLoginResponse = MemberLoginResponse.of(accessToken, member);
-    OAuthProvider oAuthProvider = getOAuthProvider();
-    Map<String, Object> attribute = Collections.EMPTY_MAP;
 
     @ParameterizedTest
     @DisplayName("소셜 로그인")
@@ -57,11 +56,13 @@ class RegularAuthServiceTest {
     public void login(final String providerName) throws Exception {
         // given
         final MemberLoginRequest memberLoginRequest = new MemberLoginRequest(providerName, code);
+        final OAuthProvider oAuthProvider = getOAuthProvider(providerName);
+        final OAuthProfile oAuthProfile = getOAuthProfile(oAuthProvider);
 
         // when
         doReturn(oAuthProvider).when(inMemoryOAuthProviderRepository).findByProviderName(providerName);
-        doReturn(Mono.just(attribute)).when(oAuthClient).getProfile(oAuthProvider, code);
-        doReturn(member).when(oAuthResultHandler).saveOrGet(attribute, providerName);
+        doReturn(Mono.just(oAuthProfile)).when(oAuthClient).getProfile(oAuthProvider, code);
+        doReturn(member).when(oAuthResultHandler).saveOrGet(oAuthProfile);
         doReturn(accessToken).when(tokenProvider).createToken(AuthPrincipal.from(member));
         final MemberLoginResponse actual = regularAuthService.login(memberLoginRequest);
         final MemberLoginResponse expected = memberLoginResponse;
@@ -76,6 +77,7 @@ class RegularAuthServiceTest {
     public void loginWhenInvalidAuthenticateCode(final String providerName) throws Exception {
         // given
         final MemberLoginRequest memberLoginRequest = new MemberLoginRequest(providerName, code);
+        final OAuthProvider oAuthProvider = getOAuthProvider(providerName);
 
         // when
         doThrow(new RuntimeException()).when(oAuthClient).getProfile(oAuthProvider, code);
@@ -85,9 +87,9 @@ class RegularAuthServiceTest {
                 .isInstanceOf(RuntimeException.class);
     }
 
-    private OAuthProvider getOAuthProvider() {
+    private OAuthProvider getOAuthProvider(final String providerName) {
         return new OAuthProvider(
-                "name",
+                providerName,
                 "clientId",
                 "clientSecret",
                 "redirectUrl",
@@ -97,5 +99,9 @@ class RegularAuthServiceTest {
                 HttpMethod.GET,
                 "profileUrl"
         );
+    }
+
+    private OAuthProfile getOAuthProfile(final OAuthProvider oAuthProvider) {
+        return OAuthProfileFactory.of(Collections.emptyMap(), oAuthProvider);
     }
 }


### PR DESCRIPTION
## 작업 내용
- OAuth의 완전한 모듈화를 위해 외부에서 사용가능한 `OAuthClient.getProfile()` 반환 값을 캡슐화하여 제공하도록 수정
  - `OAuthClient.getProfile()` 반환 타입을 `Map<String, Object>` 에서 `OAuthProfile`로 수정
- `OAuthProfileFactory.of()` 예외 클래스 커스텀

## 테스트
### Service
<img width="556" alt="image" src="https://github.com/user-attachments/assets/e78dd7b6-abbe-47d3-9366-754ad73d68e9">

### Controller
__구글__
<img width="1249" alt="image" src="https://github.com/user-attachments/assets/f1e7ec99-c5d2-4322-9b6b-3e4c5d452a12">

__카카오__
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/aa36c2f8-5d6b-4b42-bca6-942d20168d32">

__네이버__
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/b2fcd47f-0208-4ac9-8894-e6bdbf0589b5">