### PR TITLE
[기능 추가] 전역 예외 처리

### DIFF
--- a/src/main/java/org/chzzk/howmeet/domain/common/error/DomainErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/error/DomainErrorCode.java
@@ -1,0 +1,8 @@
+package org.chzzk.howmeet.domain.common.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface DomainErrorCode {
+    HttpStatus getStatus();
+    String getMessage();
+}

--- a/src/main/java/org/chzzk/howmeet/domain/common/error/DomainException.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/error/DomainException.java
@@ -1,0 +1,14 @@
+package org.chzzk.howmeet.domain.common.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class DomainException extends RuntimeException {
+    private final HttpStatus status;
+
+    public DomainException(final DomainErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.status = errorCode.getStatus();
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/exception/MemberErrorCode.java
@@ -1,10 +1,11 @@
 package org.chzzk.howmeet.domain.regular.member.exception;
 
 import lombok.Getter;
+import org.chzzk.howmeet.domain.common.error.DomainErrorCode;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum MemberErrorCode {
+public enum MemberErrorCode implements DomainErrorCode {
     MEMBER_NOT_FOUND("회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/exception/MemberException.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/exception/MemberException.java
@@ -1,10 +1,9 @@
 package org.chzzk.howmeet.domain.regular.member.exception;
 
-public class MemberException extends RuntimeException {
-    private final MemberErrorCode errorCode;
+import org.chzzk.howmeet.domain.common.error.DomainException;
 
+public class MemberException extends DomainException {
     public MemberException(final MemberErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+        super(errorCode);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/exception/RoomErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/exception/RoomErrorCode.java
@@ -1,10 +1,11 @@
 package org.chzzk.howmeet.domain.regular.room.exception;
 
 import lombok.Getter;
+import org.chzzk.howmeet.domain.common.error.DomainErrorCode;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum RoomErrorCode {
+public enum RoomErrorCode implements DomainErrorCode {
     ROOM_NOT_FOUND("요청하신 방을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     ROOM_MEMBER_NOT_FOUND("해당 방의 멤버를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_ROOM_MEMBER("해당 멤버가 지정된 방에 속하지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/exception/RoomException.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/exception/RoomException.java
@@ -1,10 +1,9 @@
 package org.chzzk.howmeet.domain.regular.room.exception;
 
-public class RoomException extends RuntimeException {
-    private final RoomErrorCode errorCode;
+import org.chzzk.howmeet.domain.common.error.DomainException;
 
+public class RoomException extends DomainException {
     public RoomException(final RoomErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+        super(errorCode);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/exception/RoomMemberErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/exception/RoomMemberErrorCode.java
@@ -1,10 +1,11 @@
 package org.chzzk.howmeet.domain.regular.room.exception;
 
 import lombok.Getter;
+import org.chzzk.howmeet.domain.common.error.DomainErrorCode;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum RoomMemberErrorCode {
+public enum RoomMemberErrorCode implements DomainErrorCode {
     ROOM_NOT_FOUND("요청하신 방을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     ROOM_MEMBER_CREATION_FAILED("해당 방의 멤버 생성에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/exception/RoomMemberException.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/exception/RoomMemberException.java
@@ -1,10 +1,9 @@
 package org.chzzk.howmeet.domain.regular.room.exception;
 
-public class RoomMemberException extends RuntimeException {
-    private final RoomMemberErrorCode errorCode;
+import org.chzzk.howmeet.domain.common.error.DomainException;
 
+public class RoomMemberException extends DomainException {
     public RoomMemberException(final RoomMemberErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+        super(errorCode);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/schedule/exception/MSErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/schedule/exception/MSErrorCode.java
@@ -1,10 +1,11 @@
 package org.chzzk.howmeet.domain.regular.schedule.exception;
 
 import lombok.Getter;
+import org.chzzk.howmeet.domain.common.error.DomainErrorCode;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum MSErrorCode {
+public enum MSErrorCode implements DomainErrorCode {
     SCHEDULE_NOT_FOUND("요청하신 일정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     ROOM_NOT_FOUND("요청하신 방을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     SCHEDULE_CREATION_FAILED("일정을 생성하는 데 실패하였습니다", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/org/chzzk/howmeet/domain/regular/schedule/exception/MSException.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/schedule/exception/MSException.java
@@ -1,10 +1,9 @@
 package org.chzzk.howmeet.domain.regular.schedule.exception;
 
-public class MSException extends RuntimeException {
-    private final MSErrorCode errorCode;
+import org.chzzk.howmeet.domain.common.error.DomainException;
 
+public class MSException extends DomainException {
     public MSException(final MSErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+        super(errorCode);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/exception/GuestErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/exception/GuestErrorCode.java
@@ -1,10 +1,11 @@
 package org.chzzk.howmeet.domain.temporary.auth.exception;
 
 import lombok.Getter;
+import org.chzzk.howmeet.domain.common.error.DomainErrorCode;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum GuestErrorCode {
+public enum GuestErrorCode implements DomainErrorCode {
     GUEST_NOT_FOUND("회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     GUEST_ALREADY_EXIST("이미 존재하는 회원입니다.", HttpStatus.BAD_REQUEST),
     INVALID_PASSWORD("비밀번호가 올바르지 않습니다", HttpStatus.BAD_REQUEST);

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/exception/GuestException.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/exception/GuestException.java
@@ -1,10 +1,9 @@
 package org.chzzk.howmeet.domain.temporary.auth.exception;
 
-public class GuestException extends RuntimeException {
-    private final GuestErrorCode errorCode;
+import org.chzzk.howmeet.domain.common.error.DomainException;
 
+public class GuestException extends DomainException {
     public GuestException(final GuestErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+        super(errorCode);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/exception/GSErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/exception/GSErrorCode.java
@@ -1,10 +1,11 @@
 package org.chzzk.howmeet.domain.temporary.schedule.exception;
 
 import lombok.Getter;
+import org.chzzk.howmeet.domain.common.error.DomainErrorCode;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum GSErrorCode {
+public enum GSErrorCode implements DomainErrorCode {
     SCHEDULE_NOT_FOUND("요청하신 일정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     SCHEDULE_CREATION_FAILED("일정을 생성하는 데 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/exception/GSException.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/exception/GSException.java
@@ -1,10 +1,9 @@
 package org.chzzk.howmeet.domain.temporary.schedule.exception;
 
-public class GSException extends RuntimeException {
-    private final GSErrorCode errorCode;
+import org.chzzk.howmeet.domain.common.error.DomainException;
 
+public class GSException extends DomainException {
     public GSException(final GSErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+        super(errorCode);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/global/error/ErrorResponse.java
+++ b/src/main/java/org/chzzk/howmeet/global/error/ErrorResponse.java
@@ -1,0 +1,23 @@
+package org.chzzk.howmeet.global.error;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ErrorResponse {
+    private int status;
+    private String message;
+
+    public static ErrorResponse of(final HttpStatus status, final String message) {
+        return new ErrorResponse(status.value(), message);
+    }
+
+    public static ErrorResponse of(final HttpStatus status, final Exception exception) {
+        return new ErrorResponse(status.value(), exception.getMessage());
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/chzzk/howmeet/global/error/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package org.chzzk.howmeet.global.error;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.chzzk.howmeet.domain.common.error.DomainException;
+import org.chzzk.howmeet.infra.error.InfraException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -45,6 +46,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DomainException.class)
     public ResponseEntity<ErrorResponse> handleBusinessException(final DomainException exception) {
+        return ResponseEntity.status(exception.getStatus())
+                .body(ErrorResponse.of(exception.getStatus(), exception.getMessage()));
+    }
+
+    @ExceptionHandler(InfraException.class)
+    public ResponseEntity<ErrorResponse> handleInfraException(final InfraException exception) {
         return ResponseEntity.status(exception.getStatus())
                 .body(ErrorResponse.of(exception.getStatus(), exception.getMessage()));
     }

--- a/src/main/java/org/chzzk/howmeet/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/chzzk/howmeet/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,63 @@
+package org.chzzk.howmeet.global.error;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.chzzk.howmeet.domain.common.error.DomainException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        log.error("예상치 못한 에러입니다. ", exception);
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(INTERNAL_SERVER_ERROR, "예상하지 못한 에러입니다."));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(final IllegalArgumentException exception) {
+        log.warn("잘못된 요청입니다. ", exception);
+        return ResponseEntity.status(BAD_REQUEST)
+                .body(ErrorResponse.of(BAD_REQUEST, "잘못된 요청입니다."));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(final ConstraintViolationException exception) {
+        return ResponseEntity.status(BAD_REQUEST)
+                .body(ErrorResponse.of(BAD_REQUEST, exception));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException exception) {
+        return ResponseEntity.status(BAD_REQUEST)
+                .body(ErrorResponse.of(BAD_REQUEST, String.join(", ", getFieldErrorMessage(exception))));
+    }
+
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(final DomainException exception) {
+        return ResponseEntity.status(exception.getStatus())
+                .body(ErrorResponse.of(exception.getStatus(), exception.getMessage()));
+    }
+
+    private List<String> getFieldErrorMessage(final MethodArgumentNotValidException exception) {
+        return exception.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .map(error -> {
+                    final String fieldName = ((FieldError) error).getField();
+                    final String message = error.getDefaultMessage();
+                    return fieldName + ": " + message;
+                })
+                .toList();
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/error/InfraException.java
+++ b/src/main/java/org/chzzk/howmeet/infra/error/InfraException.java
@@ -1,0 +1,14 @@
+package org.chzzk.howmeet.infra.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class InfraException extends RuntimeException {
+    private final HttpStatus status;
+
+    public InfraException(final String message, final HttpStatus status) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/OAuthClientException.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/OAuthClientException.java
@@ -1,0 +1,12 @@
+package org.chzzk.howmeet.infra.oauth.exception;
+
+import lombok.Getter;
+import org.chzzk.howmeet.infra.error.InfraException;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class OAuthClientException extends InfraException {
+    public OAuthClientException(final String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/OAuthServerException.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/OAuthServerException.java
@@ -1,0 +1,10 @@
+package org.chzzk.howmeet.infra.oauth.exception;
+
+import org.chzzk.howmeet.infra.error.InfraException;
+import org.springframework.http.HttpStatus;
+
+public class OAuthServerException extends InfraException {
+    public OAuthServerException(final String message) {
+        super(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/UnsupportedProviderException.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/UnsupportedProviderException.java
@@ -2,7 +2,7 @@ package org.chzzk.howmeet.infra.oauth.exception;
 
 import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
 
-public class UnsupportedProviderException extends RuntimeException {
+public class UnsupportedProviderException extends OAuthClientException {
     public UnsupportedProviderException(final String providerName) {
         super(providerName + " 소셜 로그인은 지원하지 않습니다.");
     }

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/OAuthProfileException.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/profile/OAuthProfileException.java
@@ -1,10 +1,11 @@
 package org.chzzk.howmeet.infra.oauth.exception.profile;
 
 import lombok.extern.slf4j.Slf4j;
+import org.chzzk.howmeet.infra.oauth.exception.OAuthClientException;
 import org.chzzk.howmeet.infra.oauth.exception.profile.response.OAuthProfileErrorResponse;
 
 @Slf4j
-public class OAuthProfileException extends RuntimeException {
+public class OAuthProfileException extends OAuthClientException {
     public OAuthProfileException(final OAuthProfileErrorResponse errorResponse) {
         super(errorResponse.getMessage());
         log.error("소셜 프로필 조회 실패. 에러 코드 : {}, 에러 메시지 : {}", errorResponse.getErrorCode(), errorResponse.getMessage());

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/OAuthTokenIssueException.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/exception/token/OAuthTokenIssueException.java
@@ -1,10 +1,11 @@
 package org.chzzk.howmeet.infra.oauth.exception.token;
 
 import lombok.extern.slf4j.Slf4j;
+import org.chzzk.howmeet.infra.oauth.exception.OAuthClientException;
 import org.chzzk.howmeet.infra.oauth.exception.token.response.OAuthTokenIssueErrorResponse;
 
 @Slf4j
-public class OAuthTokenIssueException extends RuntimeException {
+public class OAuthTokenIssueException extends OAuthClientException {
     public OAuthTokenIssueException(final OAuthTokenIssueErrorResponse errorResponse) {
         super(errorResponse.getMessage());
         log.error("소셜 토큰 발급 실패. 에러 코드 : {}, 에러 메시지 : {}", errorResponse.getErrorCode(), errorResponse.getMessage());

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/service/ProfileFailHandler.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/service/ProfileFailHandler.java
@@ -1,6 +1,7 @@
 package org.chzzk.howmeet.infra.oauth.service;
 
 import org.chzzk.howmeet.infra.oauth.exception.OAuthErrorResponseFactory;
+import org.chzzk.howmeet.infra.oauth.exception.OAuthServerException;
 import org.chzzk.howmeet.infra.oauth.exception.profile.OAuthProfileException;
 import org.chzzk.howmeet.infra.oauth.exception.profile.response.OAuthProfileErrorResponse;
 import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
@@ -16,10 +17,10 @@ public class ProfileFailHandler {
                 .map(OAuthProfileException::new);
     }
 
-    public Mono<IllegalStateException> handle5xxError(final ClientResponse clientResponse,
+    public Mono<OAuthServerException> handle5xxError(final ClientResponse clientResponse,
                                                       final OAuthProvider oAuthProvider) {
         return clientResponse.bodyToMono(OAuthErrorResponseFactory.getProfileResponseClassFrom(oAuthProvider.name()))
                 .map(OAuthProfileErrorResponse::getMessage)
-                .map(IllegalStateException::new);
+                .map(OAuthServerException::new);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/service/TokenIssueFailHandler.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/service/TokenIssueFailHandler.java
@@ -1,6 +1,7 @@
 package org.chzzk.howmeet.infra.oauth.service;
 
 import org.chzzk.howmeet.infra.oauth.exception.OAuthErrorResponseFactory;
+import org.chzzk.howmeet.infra.oauth.exception.OAuthServerException;
 import org.chzzk.howmeet.infra.oauth.exception.token.OAuthTokenIssueException;
 import org.chzzk.howmeet.infra.oauth.exception.token.response.OAuthTokenIssueErrorResponse;
 import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
@@ -16,10 +17,10 @@ public class TokenIssueFailHandler {
                 .map(OAuthTokenIssueException::new);
     }
 
-    public Mono<IllegalStateException> handle5xxError(final ClientResponse clientResponse,
+    public Mono<OAuthServerException> handle5xxError(final ClientResponse clientResponse,
                                                       final OAuthProvider oAuthProvider) {
         return clientResponse.bodyToMono(OAuthErrorResponseFactory.getTokenIssueResponseClassFrom(oAuthProvider.name()))
                 .map(OAuthTokenIssueErrorResponse::getMessage)
-                .map(IllegalStateException::new);
+                .map(OAuthServerException::new);
     }
 }


### PR DESCRIPTION
## 작업 내용
- 전역 예외 처리 AOP 클래스 `GlobalExceptionHandler` 추가
  - `@RequestBody` 에서 발생하는 예외 (`MethodArgumentNotValidException`) 핸들링
  - `DomainException` 핸들링
  - `InfraException` 핸들링
  - 잘못된 파라미터로 발생하는 예외(`IllegalArgumentException`) 핸들링
  - 그 외 오류 핸들링
- 도메인 예외 클래스(e.g. `MemberException`, `GuestException` 등) 을 포괄하는 `DomainException` 추가
- 도메인 에러 코드(e.g. `MemberErrorCode`, `GuestErrorCode 등)을 추상화하는 `DomainErrorCode` 추가
- 인프라 예외 클래스(e.g. OAuthException 등)을 포괄하는 `InfraException` 추가


## 테스트
### Controller
__IllegalArgumentException 핸들링__
<img width="1244" alt="image" src="https://github.com/user-attachments/assets/c9db7b10-74b7-4d75-beef-e9dfbf0f988e">

__InfraException 핸들링__
<img width="1249" alt="image" src="https://github.com/user-attachments/assets/80a2f4d1-0476-47d7-8268-f6edf7fda07f">
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/62a44c19-0bd8-4073-ad78-c1a9f32ab023">

__DomainException 핸들링__
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/a83da106-52e6-48af-a41b-1040382a404e">

__MethodArgumentNotValidException 핸들링__
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/311d504c-8227-44ea-8566-9be9252b7d80">

