### PR TITLE
[기능 수정] 인증 인터셉터 SQL문

### DIFF
--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberQueryDSL.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberQueryDSL.java
@@ -1,0 +1,7 @@
+package org.chzzk.howmeet.domain.regular.member.repository;
+
+import org.springframework.data.repository.query.Param;
+
+public interface MemberQueryDSL {
+    boolean existsByMemberId(@Param("memberId") final Long memberId);
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberQueryDSLImpl.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberQueryDSLImpl.java
@@ -1,0 +1,21 @@
+package org.chzzk.howmeet.domain.regular.member.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static org.chzzk.howmeet.domain.regular.member.entity.QMember.member;
+
+@RequiredArgsConstructor
+public class MemberQueryDSLImpl implements MemberQueryDSL {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByMemberId(final Long memberId) {
+        final Integer fetchFirst = queryFactory.selectOne()
+                .from(member)
+                .where(member.id.eq(memberId))
+                .fetchFirst();
+
+        return fetchFirst != null;
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberRepository.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/repository/MemberRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryDSL {
     Optional<Member> findBySocialId(final String socialId);
 
     @Query("SELECT NEW org.chzzk.howmeet.domain.regular.member.dto.summary.dto.MemberSummaryDto(m.id, m.nickname) " +

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/repository/GuestQueryDSL.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/repository/GuestQueryDSL.java
@@ -4,5 +4,6 @@ import org.chzzk.howmeet.domain.common.model.Nickname;
 import org.springframework.data.repository.query.Param;
 
 public interface GuestQueryDSL {
+    boolean existsByGuestId(@Param("guestId") final Long guestId);
     boolean existsByGuestScheduleIdAndNickname(@Param("guestScheduleId") final Long guestScheduleId, @Param("nickname") final Nickname nickname);
 }

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/repository/GuestQueryDSLImpl.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/repository/GuestQueryDSLImpl.java
@@ -11,6 +11,16 @@ public class GuestQueryDSLImpl implements GuestQueryDSL {
     private final JPAQueryFactory queryFactory;
 
     @Override
+    public boolean existsByGuestId(final Long guestId) {
+        final Integer fetchFirst = queryFactory.selectOne()
+                .from(guest)
+                .where(guest.id.eq(guestId))
+                .fetchFirst();
+
+        return fetchFirst != null;
+    }
+
+    @Override
     public boolean existsByGuestScheduleIdAndNickname(final Long guestScheduleId, final Nickname nickname) {
         final Integer fetchFirst = queryFactory.selectOne()
                 .from(guest)

--- a/src/main/java/org/chzzk/howmeet/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/org/chzzk/howmeet/global/interceptor/AuthenticationInterceptor.java
@@ -88,7 +88,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
     private void validateMember(final AuthPrincipal authPrincipal) {
         final Long id = authPrincipal.id();
-        if (!guestRepository.existsById(id) && !memberRepository.existsById(id)) {
+        if (!guestRepository.existsByGuestId(id) && !memberRepository.existsByMemberId(id)) {
             throw new AuthException(JWT_INVALID_SUBJECT);
         }
     }


### PR DESCRIPTION
## 작업 내용
- `AuthenticationInterceptor` 에서 `GuestRepository`, `MemberRepository` 의 `existsById()` SQL 개선
  - JPA `existsById()` 는 `count(*)` 을 사용하여 모든 레코드를 조회하므로 성능이 좋지 않음
  - QueryDSL 을 통해 `SELECT 1 LIMIT 1` 사용

## 테스트
__기존 SQL (existsById() 사용)__
![image](https://github.com/user-attachments/assets/90ec3ebe-ecab-49ed-9780-885400b25f10)

__수정된 SQL (SELECT 1 LIMIT 1) 사용__
![image](https://github.com/user-attachments/assets/184fcb66-3eaf-40ac-884e-09ada160637b)
