### PR TITLE
[기능 수정] 1회용 회원 로그인

### DIFF
--- a/src/main/java/org/chzzk/howmeet/domain/common/exception/NicknameErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/exception/NicknameErrorCode.java
@@ -1,10 +1,11 @@
 package org.chzzk.howmeet.domain.common.exception;
 
 import lombok.Getter;
+import org.chzzk.howmeet.domain.common.error.DomainErrorCode;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum NicknameErrorCode {
+public enum NicknameErrorCode implements DomainErrorCode {
     INVALID_NICKNAME("닉네임이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;

--- a/src/main/java/org/chzzk/howmeet/domain/common/exception/NicknameException.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/exception/NicknameException.java
@@ -1,10 +1,9 @@
 package org.chzzk.howmeet.domain.common.exception;
 
-public class NicknameException extends RuntimeException {
-    private final NicknameErrorCode errorCode;
+import org.chzzk.howmeet.domain.common.error.DomainException;
 
+public class NicknameException extends DomainException {
     public NicknameException(final NicknameErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+        super(errorCode);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/record/controller/MSRecordController.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/record/controller/MSRecordController.java
@@ -1,18 +1,19 @@
 package org.chzzk.howmeet.domain.regular.record.controller;
 
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.domain.common.auth.annotation.Authenticated;
 import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
-import org.chzzk.howmeet.domain.regular.record.dto.get.MSRecordGetRequest;
 import org.chzzk.howmeet.domain.regular.record.dto.post.MSRecordPostRequest;
 import org.chzzk.howmeet.domain.regular.record.service.MSRecordService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @RequiredArgsConstructor
 @RequestMapping("/ms-record")
@@ -30,8 +31,9 @@ public class MSRecordController {
     }
 
     @GetMapping("/{roomId}/{msId}")
-    public ResponseEntity<?> getMSRecord(@PathVariable(value = "roomId") final Long roomId, @PathVariable(value = "msId") final Long msId ,
-            @Authenticated final AuthPrincipal authPrincipal) {
+    public ResponseEntity<?> getMSRecord(@PathVariable(value = "roomId") final Long roomId,
+                                         @PathVariable(value = "msId") final Long msId ,
+                                         @Authenticated final AuthPrincipal authPrincipal) {
         return ResponseEntity.ok(msRecordService.getMSRecord(roomId, msId, authPrincipal));
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/controller/GuestController.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/controller/GuestController.java
@@ -3,16 +3,12 @@ package org.chzzk.howmeet.domain.temporary.auth.controller;
 import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.domain.temporary.auth.dto.login.request.GuestLoginRequest;
 import org.chzzk.howmeet.domain.temporary.auth.dto.login.response.GuestLoginResponse;
-import org.chzzk.howmeet.domain.temporary.auth.dto.signup.request.GuestSignupRequest;
-import org.chzzk.howmeet.domain.temporary.auth.dto.signup.response.GuestSignupResponse;
 import org.chzzk.howmeet.domain.temporary.auth.service.GuestService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import static org.springframework.http.HttpStatus.CREATED;
 
 @RequiredArgsConstructor
 @RequestMapping("/auth")
@@ -24,12 +20,5 @@ public class GuestController {
     public ResponseEntity<?> login(@RequestBody final GuestLoginRequest guestLoginRequest) {
         final GuestLoginResponse guestLoginResponse = guestService.login(guestLoginRequest);
         return ResponseEntity.ok(guestLoginResponse);
-    }
-
-    @PostMapping("/signup")
-    public ResponseEntity<?> signup(@RequestBody final GuestSignupRequest guestSignupRequest) {
-        final GuestSignupResponse guestSignupResponse = guestService.signup(guestSignupRequest);
-        return ResponseEntity.status(CREATED)
-                .body(guestSignupResponse);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/entity/Guest.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/entity/Guest.java
@@ -21,7 +21,7 @@ import org.chzzk.howmeet.domain.common.model.converter.NicknameConverter;
 import org.chzzk.howmeet.domain.temporary.auth.exception.GuestException;
 import org.chzzk.howmeet.domain.temporary.auth.util.PasswordEncoder;
 
-import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.INVALID_PASSWORD;
+import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.NOT_MATCHED_PASSWORD;
 
 @Entity
 @Getter
@@ -56,7 +56,7 @@ public class Guest extends BaseEntity implements UserDetails, NicknameProvider {
 
     public void validatePassword(final String planePassword, final PasswordEncoder passwordEncoder) {
         if (!password.isMatch(planePassword, passwordEncoder)) {
-            throw new GuestException(INVALID_PASSWORD);
+            throw new GuestException(NOT_MATCHED_PASSWORD);
         }
     }
 

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/exception/GuestErrorCode.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/exception/GuestErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum GuestErrorCode implements DomainErrorCode {
     GUEST_NOT_FOUND("회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     GUEST_ALREADY_EXIST("이미 존재하는 회원입니다.", HttpStatus.BAD_REQUEST),
-    INVALID_PASSWORD("비밀번호가 올바르지 않습니다", HttpStatus.BAD_REQUEST);
+    INVALID_PASSWORD("비밀번호가 올바르지 않습니다", HttpStatus.BAD_REQUEST),
+    NOT_MATCHED_PASSWORD("비밀번호가 틀렸습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestFindService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestFindService.java
@@ -1,0 +1,21 @@
+package org.chzzk.howmeet.domain.temporary.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.common.model.Nickname;
+import org.chzzk.howmeet.domain.temporary.auth.entity.Guest;
+import org.chzzk.howmeet.domain.temporary.auth.repository.GuestRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class GuestFindService {
+    private final GuestRepository guestRepository;
+
+    public Optional<Guest> find(final Long guestScheduleId, final String nickname) {
+        return guestRepository.findByGuestScheduleIdAndNickname(guestScheduleId, Nickname.from(nickname));
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestSaveService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestSaveService.java
@@ -4,21 +4,33 @@ import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.domain.common.model.EncodedPassword;
 import org.chzzk.howmeet.domain.temporary.auth.entity.Guest;
 import org.chzzk.howmeet.domain.temporary.auth.repository.GuestRepository;
+import org.chzzk.howmeet.domain.temporary.schedule.exception.GSException;
+import org.chzzk.howmeet.domain.temporary.schedule.repository.GSRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.chzzk.howmeet.domain.temporary.schedule.exception.GSErrorCode.SCHEDULE_NOT_FOUND;
 
 @RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
 public class GuestSaveService {
     private final GuestRepository guestRepository;
+    private final GSRepository gsRepository;
 
     @Transactional
     public Guest save(final Long guestScheduleId, final String nickname, final EncodedPassword encodedPassword) {
+        validateGuestScheduleId(guestScheduleId);
         return guestRepository.save(Guest.of(
                 guestScheduleId,
                 nickname,
                 encodedPassword
         ));
+    }
+
+    private void validateGuestScheduleId(final Long guestScheduleId) {
+        if (!gsRepository.existsByGuestScheduleId(guestScheduleId)) {
+            throw new GSException(SCHEDULE_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestSaveService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestSaveService.java
@@ -1,0 +1,24 @@
+package org.chzzk.howmeet.domain.temporary.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.common.model.EncodedPassword;
+import org.chzzk.howmeet.domain.temporary.auth.entity.Guest;
+import org.chzzk.howmeet.domain.temporary.auth.repository.GuestRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class GuestSaveService {
+    private final GuestRepository guestRepository;
+
+    @Transactional
+    public Guest save(final Long guestScheduleId, final String nickname, final EncodedPassword encodedPassword) {
+        return guestRepository.save(Guest.of(
+                guestScheduleId,
+                nickname,
+                encodedPassword
+        ));
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestService.java
@@ -3,75 +3,39 @@ package org.chzzk.howmeet.domain.temporary.auth.service;
 import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
 import org.chzzk.howmeet.domain.common.model.EncodedPassword;
-import org.chzzk.howmeet.domain.common.model.Nickname;
 import org.chzzk.howmeet.domain.temporary.auth.dto.login.request.GuestLoginRequest;
 import org.chzzk.howmeet.domain.temporary.auth.dto.login.response.GuestLoginResponse;
-import org.chzzk.howmeet.domain.temporary.auth.dto.signup.request.GuestSignupRequest;
-import org.chzzk.howmeet.domain.temporary.auth.dto.signup.response.GuestSignupResponse;
 import org.chzzk.howmeet.domain.temporary.auth.entity.Guest;
-import org.chzzk.howmeet.domain.temporary.auth.exception.GuestException;
-import org.chzzk.howmeet.domain.temporary.auth.repository.GuestRepository;
 import org.chzzk.howmeet.domain.temporary.auth.util.PasswordEncoder;
-import org.chzzk.howmeet.domain.temporary.schedule.repository.GSRepository;
 import org.chzzk.howmeet.global.util.TokenProvider;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.GUEST_ALREADY_EXIST;
-import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.GUEST_NOT_FOUND;
 
 @RequiredArgsConstructor
 @Service
-@Transactional(readOnly = true)
 public class GuestService {
-    private final GuestRepository guestRepository;
-    private final GSRepository gsRepository;
+    private final GuestFindService guestFindService;
+    private final GuestSaveService guestSaveService;
     private final PasswordEncoder passwordEncoder;
     private final PasswordValidator passwordValidator;
     private final TokenProvider tokenProvider;
 
     public GuestLoginResponse login(final GuestLoginRequest guestLoginRequest) {
         passwordValidator.validate(guestLoginRequest.password());
-        final Guest guest = findGuestByNicknameAndScheduleId(guestLoginRequest.nickname(), guestLoginRequest.guestScheduleId());
+        final Guest guest = saveOrGetGuest(guestLoginRequest);
         guest.validatePassword(guestLoginRequest.password(), passwordEncoder);
-        final AuthPrincipal authPrincipal = AuthPrincipal.from(guest);
-        final String accessToken = tokenProvider.createToken(authPrincipal);
+        final String accessToken = getAccessToken(guest);
         return GuestLoginResponse.of(accessToken, guest);
     }
 
-    @Transactional
-    public GuestSignupResponse signup(final GuestSignupRequest guestSignupRequest) {
-        final String password = guestSignupRequest.password();
-        passwordValidator.validate(password);
-
-        final Long guestScheduleId = guestSignupRequest.guestScheduleId();
-        final String nickname = guestSignupRequest.nickname();
-        validateDuplicateNicknameInScheduleId(guestScheduleId, nickname);
-        validateGuestScheduleId(guestScheduleId);   // TODO 8/24 김민우 : SQL을 2개로 나눠서 Phantom Read 발생할까?
-
-        final Guest guest = Guest.of(
-                guestScheduleId,
-                nickname,
-                EncodedPassword.of(password, passwordEncoder)
-        );
-
-        return GuestSignupResponse.of(guestRepository.save(guest));
+    private Guest saveOrGetGuest(final GuestLoginRequest guestLoginRequest) {
+        final Long guestScheduleId = guestLoginRequest.guestScheduleId();
+        final String nickname = guestLoginRequest.nickname();
+        return guestFindService.find(guestScheduleId, nickname)
+                .orElseGet(() -> guestSaveService.save(guestScheduleId, nickname, EncodedPassword.of(guestLoginRequest.password(), passwordEncoder)));
     }
 
-    private void validateGuestScheduleId(final Long guestScheduleId) {
-        if (!gsRepository.existsByGuestScheduleId(guestScheduleId)) {
-            throw new IllegalArgumentException();   // TODO 8/24 김민우 : 비회원 일정 예외 처리 구현 후 수정 예정
-        }
-    }
-
-    private void validateDuplicateNicknameInScheduleId(final Long guestScheduleId, final String nickname) {
-        if (guestRepository.existsByGuestScheduleIdAndNickname(guestScheduleId, Nickname.from(nickname))) {
-            throw new GuestException(GUEST_ALREADY_EXIST);
-        }
-    }
-
-    private Guest findGuestByNicknameAndScheduleId(final String nickname, final Long guestScheduleId) {
-        return guestRepository.findByGuestScheduleIdAndNickname(guestScheduleId, Nickname.from(nickname))
-                .orElseThrow(() -> new GuestException(GUEST_NOT_FOUND));
+    private String getAccessToken(final Guest guest) {
+        final AuthPrincipal authPrincipal = AuthPrincipal.from(guest);
+        return tokenProvider.createToken(authPrincipal);
     }
 }

--- a/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestFindServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestFindServiceTest.java
@@ -1,0 +1,46 @@
+package org.chzzk.howmeet.domain.temporary.auth.service;
+
+import org.chzzk.howmeet.domain.common.model.Nickname;
+import org.chzzk.howmeet.domain.temporary.auth.entity.Guest;
+import org.chzzk.howmeet.domain.temporary.auth.repository.GuestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.chzzk.howmeet.fixture.GuestFixture.KIM;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class GuestFindServiceTest {
+    @Mock
+    GuestRepository guestRepository;
+
+    @InjectMocks
+    GuestFindService guestFindService;
+
+    Long guestScheduleId = 1L;
+    Guest guest = KIM.생성();
+    String nickname = KIM.getNickname();
+
+    @Test
+    @DisplayName("")
+    public void find() throws Exception {
+        // given
+        final Guest expect = guest;
+
+        // when
+        doReturn(Optional.of(expect)).when(guestRepository)
+                .findByGuestScheduleIdAndNickname(guestScheduleId, Nickname.from(nickname));
+        final Guest actual = guestFindService.find(guestScheduleId, nickname)
+                .get();
+
+        // then
+        assertThat(actual).isEqualTo(expect);
+    }
+}

--- a/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestSaveServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestSaveServiceTest.java
@@ -1,0 +1,67 @@
+package org.chzzk.howmeet.domain.temporary.auth.service;
+
+import org.chzzk.howmeet.domain.common.model.EncodedPassword;
+import org.chzzk.howmeet.domain.temporary.auth.entity.Guest;
+import org.chzzk.howmeet.domain.temporary.auth.repository.GuestRepository;
+import org.chzzk.howmeet.domain.temporary.schedule.exception.GSException;
+import org.chzzk.howmeet.domain.temporary.schedule.repository.GSRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.chzzk.howmeet.domain.temporary.schedule.exception.GSErrorCode.SCHEDULE_NOT_FOUND;
+import static org.chzzk.howmeet.fixture.GuestFixture.KIM;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class GuestSaveServiceTest {
+    @Mock
+    GuestRepository guestRepository;
+
+    @Mock
+    GSRepository gsRepository;
+
+    @InjectMocks
+    GuestSaveService guestSaveService;
+
+    Long guestScheduleId = 1L;
+    Guest guest = KIM.생성();
+    EncodedPassword encodedPassword = guest.getPassword();
+    String nickname = KIM.getNickname();
+
+    @Test
+    @DisplayName("1회용 회원 저장")
+    public void save() throws Exception {
+        // given
+        final Guest expect = guest;
+
+        // when
+        doReturn(true).when(gsRepository)
+                .existsByGuestScheduleId(guestScheduleId);
+        doReturn(expect).when(guestRepository)
+                .save(any());
+        final Guest actual = guestSaveService.save(guestScheduleId, nickname, encodedPassword);
+
+        // then
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @Test
+    @DisplayName("1회용 회원 저장시 일정 ID가 잘못되면 예외 발생")
+    public void saveWhenInvalidGuestScheduleId() throws Exception {
+        // when
+        doReturn(false).when(gsRepository)
+                .existsByGuestScheduleId(guestScheduleId);
+
+        // then
+        assertThatThrownBy(() -> guestSaveService.save(guestScheduleId, nickname, encodedPassword))
+                .isInstanceOf(GSException.class)
+                .hasMessageContaining(SCHEDULE_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestServiceTest.java
@@ -6,12 +6,10 @@ import org.chzzk.howmeet.domain.common.model.EncodedPassword;
 import org.chzzk.howmeet.domain.temporary.auth.controller.GuestController;
 import org.chzzk.howmeet.domain.temporary.auth.dto.login.request.GuestLoginRequest;
 import org.chzzk.howmeet.domain.temporary.auth.dto.login.response.GuestLoginResponse;
-import org.chzzk.howmeet.domain.temporary.auth.dto.signup.request.GuestSignupRequest;
-import org.chzzk.howmeet.domain.temporary.auth.dto.signup.response.GuestSignupResponse;
 import org.chzzk.howmeet.domain.temporary.auth.entity.Guest;
 import org.chzzk.howmeet.domain.temporary.auth.exception.GuestException;
-import org.chzzk.howmeet.domain.temporary.auth.repository.GuestRepository;
 import org.chzzk.howmeet.domain.temporary.auth.util.PasswordEncoder;
+import org.chzzk.howmeet.domain.temporary.schedule.exception.GSException;
 import org.chzzk.howmeet.global.util.TokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,13 +25,9 @@ import java.util.Optional;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import static org.chzzk.howmeet.domain.common.exception.NicknameErrorCode.INVALID_NICKNAME;
 import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.GUEST_ALREADY_EXIST;
-import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.GUEST_NOT_FOUND;
 import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.INVALID_PASSWORD;
 import static org.chzzk.howmeet.fixture.GuestFixture.KIM;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -49,7 +43,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs
 class GuestServiceTest extends RestDocsTest {
     @Mock
-    GuestRepository guestRepository;
+    GuestFindService guestFindService;
+
+    @Mock
+    GuestSaveService guestSaveService;
 
     @Mock
     PasswordEncoder passwordEncoder;
@@ -75,11 +72,9 @@ class GuestServiceTest extends RestDocsTest {
     String accessToken = "accessToken";
     GuestLoginRequest guestLoginRequest = new GuestLoginRequest(guest.getGuestScheduleId(), nickname, password);;
     GuestLoginResponse guestLoginResponse = GuestLoginResponse.of(accessToken, guest);
-    GuestSignupRequest guestSignupRequest = new GuestSignupRequest(guest.getGuestScheduleId(), nickname, password);
-    GuestSignupResponse guestSignupResponse = GuestSignupResponse.of(guest);
 
     @Test
-    @DisplayName("1회용 로그인")
+    @DisplayName("1회용 로그인 (기존 회원)")
     public void login() throws Exception {
         // given
         final GuestLoginResponse expect = guestLoginResponse;
@@ -89,8 +84,8 @@ class GuestServiceTest extends RestDocsTest {
                 .validate(password);
         doReturn(true).when(passwordEncoder)
                 .matches(password, encodedPassword.getValue());
-        doReturn(Optional.of(guest)).when(guestRepository)
-                .findByGuestScheduleIdAndNickname(guest.getGuestScheduleId(), guest.getNickname());
+        doReturn(Optional.of(guest)).when(guestFindService)
+                .find(guest.getGuestScheduleId(), guest.getNickname().getValue());
         doReturn(accessToken).when(tokenProvider)
                 .createToken(AuthPrincipal.from(guest));
         final GuestLoginResponse actual = guestService.login(guestLoginRequest);
@@ -118,21 +113,6 @@ class GuestServiceTest extends RestDocsTest {
     }
 
     @Test
-    @DisplayName("1회용 로그인 시 일치하는 회원이 없는 경우 예외 발생")
-    public void loginWhenInvalidNickname() throws Exception {
-        // when
-        doNothing().when(passwordValidator)
-                .validate(password);
-        doReturn(Optional.empty()).when(guestRepository)
-                .findByGuestScheduleIdAndNickname(guest.getGuestScheduleId(), guest.getNickname());
-
-        // then
-        assertThatThrownBy(() -> guestService.login(guestLoginRequest))
-                .isInstanceOf(GuestException.class)
-                .hasMessageContaining(GUEST_NOT_FOUND.getMessage());
-    }
-
-    @Test
     @DisplayName("1회용 로그인 시 비밀번호 검증 실패시 예외 발생")
     public void loginWhenInvalidPassword() throws Exception {
         // when
@@ -151,8 +131,8 @@ class GuestServiceTest extends RestDocsTest {
         // when
         doNothing().when(passwordValidator)
                 .validate(password);
-        doReturn(Optional.of(guest)).when(guestRepository)
-                .findByGuestScheduleIdAndNickname(guest.getGuestScheduleId(), guest.getNickname());
+        doReturn(Optional.of(guest)).when(guestFindService)
+                .find(guest.getGuestScheduleId(), guest.getNickname().getValue());
         doReturn(false).when(passwordEncoder)
                 .matches(password, encodedPassword.getValue());
 
@@ -163,62 +143,36 @@ class GuestServiceTest extends RestDocsTest {
     }
 
     @Test
-    @DisplayName("1회용 회원가입")
+    @DisplayName("1회용 로그인 일정 ID가 잘못된 경우 예외 발생")
+    public void signupWhenInvalidScheduleId() throws Exception {
+        // when
+        doThrow(GSException.class).when(guestSaveService)
+                .save(guest.getGuestScheduleId(), guest.getNickname().getValue(), encodedPassword);
+
+        // then
+        assertThatThrownBy(() -> guestService.login(guestLoginRequest))
+                .isInstanceOf(GuestException.class)
+                .hasMessageContaining(GUEST_ALREADY_EXIST.getMessage());
+    }
+
+    @Test
+    @DisplayName("1회용 로그인 (신규 회원)")
     public void signup() throws Exception {
         // given
-        final GuestSignupResponse expect = guestSignupResponse;
+        final GuestLoginResponse expect = guestLoginResponse;
 
         // when
         doNothing().when(passwordValidator)
                 .validate(password);
-        doReturn(false).when(guestRepository)
-                .existsByGuestScheduleIdAndNickname(guest.getGuestScheduleId(), guest.getNickname());
+        doReturn(Optional.empty()).when(guestFindService)
+                .find(guest.getGuestScheduleId(), guest.getNickname().getValue());
         doReturn(encodedPassword.getValue()).when(passwordEncoder)
                 .encode(password);
-        doReturn(guest).when(guestRepository)
-                .save(any());
-        final GuestSignupResponse actual = guestService.signup(guestSignupRequest);
+        doReturn(guest).when(guestSaveService)
+                .save(guestLoginRequest.guestScheduleId(), guestLoginRequest.nickname(), encodedPassword);
+        final GuestLoginResponse actual = guestService.login(guestLoginRequest);
 
         // then
         assertThat(actual).isEqualTo(expect);
-    }
-
-    @Test
-    @DisplayName("1회용 회원가입시 닉네임 중복시 예외 발생")
-    public void signupWhenDuplicatedNickname() throws Exception {
-        // when
-        doReturn(true).when(guestRepository)
-                .existsByGuestScheduleIdAndNickname(guest.getGuestScheduleId(), guest.getNickname());
-
-        // then
-        assertThatThrownBy(() -> guestService.signup(guestSignupRequest))
-                .isInstanceOf(GuestException.class)
-                .hasMessageContaining(GUEST_ALREADY_EXIST.getMessage());
-    }
-
-    @Test
-    @DisplayName("1회용 회원가입시 비밀번호 검증 실패시 예외 발생")
-    public void signupWhenInvalidPassword() throws Exception {
-        // when
-        doThrow(new GuestException(INVALID_PASSWORD)).when(passwordValidator)
-                .validate(password);
-
-        // then
-        assertThatThrownBy(() -> guestService.signup(guestSignupRequest))
-                .isInstanceOf(GuestException.class)
-                .hasMessageContaining(INVALID_PASSWORD.getMessage());
-    }
-
-    @Test
-    @DisplayName("1회용 회원가입시 일정 ID가 잘못된 경우 예외 발생")
-    public void signupWhenInvalidScheduleId() throws Exception {
-        // when
-        doReturn(true).when(guestRepository)
-                .existsByGuestScheduleIdAndNickname(guest.getGuestScheduleId(), guest.getNickname());
-
-        // then
-        assertThatThrownBy(() -> guestService.signup(guestSignupRequest))
-                .isInstanceOf(GuestException.class)
-                .hasMessageContaining(GUEST_ALREADY_EXIST.getMessage());
     }
 }

--- a/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/temporary/auth/service/GuestServiceTest.java
@@ -25,6 +25,7 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.docume
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.INVALID_PASSWORD;
+import static org.chzzk.howmeet.domain.temporary.auth.exception.GuestErrorCode.NOT_MATCHED_PASSWORD;
 import static org.chzzk.howmeet.fixture.GuestFixture.KIM;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -137,7 +138,7 @@ class GuestServiceTest extends RestDocsTest {
         // then
         assertThatThrownBy(() -> guestService.login(guestLoginRequest))
                 .isInstanceOf(GuestException.class)
-                .hasMessageContaining(INVALID_PASSWORD.getMessage());
+                .hasMessageContaining(NOT_MATCHED_PASSWORD.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
- 1회용 회원가입 로그인 API 통합
  - 신규 회원이면 `INSERT`
  - 기존 회원이면 `SELECT`
- `GuestFindService`, `GuestSaveService` 추가
  - 신규/기존 회원 여부에 따라 트랜잭션 최소화
  - 신규 회원이면 `GuestFindService.find()`를 호출하면서 readOnly 트랜잭션 시작
  - 기존 회원이면 `GuestSaveService.save()`를 호출하면서 트랜잭션 시작

## 테스트
### Repository
<img width="576" alt="image" src="https://github.com/user-attachments/assets/64d0020d-ead0-4a5c-8e4e-dff7c282dedb">

### Service
<img width="549" alt="image" src="https://github.com/user-attachments/assets/f4484a7e-3362-44e1-8644-071e12ebc0e3">

### Controller
__정상__
<img width="1249" alt="image" src="https://github.com/user-attachments/assets/4176a526-1275-459e-8964-146a4a644a8d">

__비밀번호 형식이 올바르지 않은 경우__
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/96c1daab-b691-4f69-a9eb-c77a4f9b0198">

__일정 ID가 잘못된 경우__
<img width="1256" alt="image" src="https://github.com/user-attachments/assets/54e4c652-62d2-4512-b8e8-f435ef42758f">

__닉네임 형식이 잘못된 경우__
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/e49fc7b7-1dfa-4e06-b448-93eeb4c1c352">

__기존 회원인데 비밀번호가 틀린 경우__
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/8d9c22ff-1893-444c-bee7-35fa650087f3">

## 기타 사항 (참고 자료, 문의 사항 등)
- 하나의 API에서 `INSERT`와 `SELECT` 둘 중 하나만 수행하여 트랜잭션을 최소화하기 위해 `GuestFindService`, `GuestSaveService`를 추가했습니다. 