### PR TITLE
[기능 추가] 회원 인가 코드 API

### DIFF
--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/controller/RegularAuthController.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/controller/RegularAuthController.java
@@ -2,10 +2,14 @@ package org.chzzk.howmeet.domain.regular.auth.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.regular.auth.dto.authorize.request.MemberAuthorizeRequest;
+import org.chzzk.howmeet.domain.regular.auth.dto.authorize.response.MemberAuthorizeResponse;
 import org.chzzk.howmeet.domain.regular.auth.dto.login.request.MemberLoginRequest;
 import org.chzzk.howmeet.domain.regular.auth.dto.login.response.MemberLoginResponse;
 import org.chzzk.howmeet.domain.regular.auth.service.RegularAuthService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +20,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class RegularAuthController {
     private final RegularAuthService regularAuthService;
+
+    @GetMapping("/authorize")
+    public ResponseEntity<?> authorize(@ModelAttribute @Valid final MemberAuthorizeRequest memberAuthorizeRequest) {
+        final MemberAuthorizeResponse memberAuthorizeResponse = regularAuthService.authorize(memberAuthorizeRequest);
+        return ResponseEntity.ok(memberAuthorizeResponse);
+    }
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid final MemberLoginRequest memberLoginRequest) {

--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/dto/authorize/request/MemberAuthorizeRequest.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/dto/authorize/request/MemberAuthorizeRequest.java
@@ -1,0 +1,6 @@
+package org.chzzk.howmeet.domain.regular.auth.dto.authorize.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberAuthorizeRequest(@NotBlank String providerName) {
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/dto/authorize/response/MemberAuthorizeResponse.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/dto/authorize/response/MemberAuthorizeResponse.java
@@ -1,0 +1,11 @@
+package org.chzzk.howmeet.domain.regular.auth.dto.authorize.response;
+
+import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
+
+import java.util.List;
+
+public record MemberAuthorizeResponse(String clientId, List<String> scopes, String method, String url) {
+    public static MemberAuthorizeResponse from(final OAuthProvider oAuthProvider) {
+        return new MemberAuthorizeResponse(oAuthProvider.clientId(), oAuthProvider.scope(), oAuthProvider.authorizeMethod().name(), oAuthProvider.authorizeUrl());
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/OAuthResultHandler.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/OAuthResultHandler.java
@@ -2,7 +2,8 @@ package org.chzzk.howmeet.domain.regular.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.domain.regular.member.entity.Member;
-import org.chzzk.howmeet.domain.regular.member.repository.MemberRepository;
+import org.chzzk.howmeet.domain.regular.member.service.MemberFindService;
+import org.chzzk.howmeet.domain.regular.member.service.MemberSaveService;
 import org.chzzk.howmeet.infra.oauth.model.profile.OAuthProfile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,11 +12,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 public class OAuthResultHandler {
-    private final MemberRepository memberRepository;
+    private final MemberFindService memberFindService;
+    private final MemberSaveService memberSaveService;
 
     @Transactional
     public Member saveOrGet(final OAuthProfile oAuthProfile) {
-        return memberRepository.findBySocialId(oAuthProfile.getSocialId())
-                        .orElseGet(() -> memberRepository.save(oAuthProfile.toEntity()));
+        return memberFindService.findBySocialId(oAuthProfile.getSocialId())
+                        .orElseGet(() -> memberSaveService.save(oAuthProfile.toEntity()));
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/auth/service/RegularAuthService.java
@@ -2,6 +2,8 @@ package org.chzzk.howmeet.domain.regular.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
+import org.chzzk.howmeet.domain.regular.auth.dto.authorize.request.MemberAuthorizeRequest;
+import org.chzzk.howmeet.domain.regular.auth.dto.authorize.response.MemberAuthorizeResponse;
 import org.chzzk.howmeet.domain.regular.auth.dto.login.request.MemberLoginRequest;
 import org.chzzk.howmeet.domain.regular.auth.dto.login.response.MemberLoginResponse;
 import org.chzzk.howmeet.domain.regular.member.entity.Member;
@@ -10,17 +12,21 @@ import org.chzzk.howmeet.infra.oauth.model.OAuthProvider;
 import org.chzzk.howmeet.infra.oauth.repository.InMemoryOAuthProviderRepository;
 import org.chzzk.howmeet.infra.oauth.service.OAuthClient;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import reactor.core.scheduler.Schedulers;
 
 @RequiredArgsConstructor
 @Service
-@Transactional(readOnly = true)
 public class RegularAuthService {
     private final InMemoryOAuthProviderRepository inMemoryOAuthProviderRepository;
     private final OAuthClient oAuthClient;
     private final OAuthResultHandler oauthResultHandler;
     private final TokenProvider tokenProvider;
+
+    public MemberAuthorizeResponse authorize(final MemberAuthorizeRequest memberAuthorizeRequest) {
+        final String providerName = memberAuthorizeRequest.providerName();
+        final OAuthProvider oAuthProvider = inMemoryOAuthProviderRepository.findByProviderName(providerName);
+        return MemberAuthorizeResponse.from(oAuthProvider);
+    }
 
     public MemberLoginResponse login(final MemberLoginRequest memberLoginRequest) {
         final OAuthProvider oAuthProvider = inMemoryOAuthProviderRepository.findByProviderName(memberLoginRequest.providerName());

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberFindService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberFindService.java
@@ -1,0 +1,25 @@
+package org.chzzk.howmeet.domain.regular.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.regular.member.dto.summary.dto.MemberSummaryDto;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
+import org.chzzk.howmeet.domain.regular.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class MemberFindService {
+    private final MemberRepository memberRepository;
+
+    public Optional<Member> findBySocialId(final String socialId) {
+        return memberRepository.findBySocialId(socialId);
+    }
+
+    public Optional<MemberSummaryDto> findSummary(final Long memberId) {
+        return memberRepository.findSummaryById(memberId);
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberFindService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberFindService.java
@@ -19,7 +19,7 @@ public class MemberFindService {
         return memberRepository.findBySocialId(socialId);
     }
 
-    public Optional<MemberSummaryDto> findSummary(final Long memberId) {
+    public Optional<MemberSummaryDto> findSummaryByMemberId(final Long memberId) {
         return memberRepository.findSummaryById(memberId);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberSaveService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberSaveService.java
@@ -1,0 +1,18 @@
+package org.chzzk.howmeet.domain.regular.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
+import org.chzzk.howmeet.domain.regular.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class MemberSaveService {
+    private final MemberRepository memberRepository;
+
+    public Member save(final Member member) {
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberService.java
@@ -5,7 +5,6 @@ import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
 import org.chzzk.howmeet.domain.regular.member.dto.summary.dto.MemberSummaryDto;
 import org.chzzk.howmeet.domain.regular.member.dto.summary.response.MemberSummaryResponse;
 import org.chzzk.howmeet.domain.regular.member.exception.MemberException;
-import org.chzzk.howmeet.domain.regular.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
 import static org.chzzk.howmeet.domain.regular.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
@@ -13,7 +12,7 @@ import static org.chzzk.howmeet.domain.regular.member.exception.MemberErrorCode.
 @RequiredArgsConstructor
 @Service
 public class MemberService {
-    private final MemberRepository memberRepository;
+    private final MemberFindService memberFindService;
 
     public MemberSummaryResponse getSummary(final AuthPrincipal authPrincipal) {
         final MemberSummaryDto memberSummaryDto = findMemberSummaryById(authPrincipal.id());
@@ -21,7 +20,7 @@ public class MemberService {
     }
 
     private MemberSummaryDto findMemberSummaryById(final Long memberId) {
-        return memberRepository.findSummaryById(memberId)
+        return memberFindService.findSummary(memberId)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/member/service/MemberService.java
@@ -20,7 +20,7 @@ public class MemberService {
     }
 
     private MemberSummaryDto findMemberSummaryById(final Long memberId) {
-        return memberFindService.findSummary(memberId)
+        return memberFindService.findSummaryByMemberId(memberId)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/model/OAuthProperties.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/model/OAuthProperties.java
@@ -7,6 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 @ConfigurationProperties(prefix = "oauth")
 @Getter
@@ -30,15 +31,25 @@ public class OAuthProperties {
         private String id;
         private String secret;
         private String redirectUrl;
+        private Set<String> scopes;
     }
 
     @Getter
     @Setter
     @ToString
     public static class Provider {
+        private Authorize authorize;
         private String name;
         private Token token;
         private Profile profile;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class Authorize {
+        private String method;
+        private String url;
     }
 
     @Getter

--- a/src/main/java/org/chzzk/howmeet/infra/oauth/model/OAuthProvider.java
+++ b/src/main/java/org/chzzk/howmeet/infra/oauth/model/OAuthProvider.java
@@ -2,9 +2,15 @@ package org.chzzk.howmeet.infra.oauth.model;
 
 import org.springframework.http.HttpMethod;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public record OAuthProvider(String name,
                             String clientId,
                             String clientSecret,
+                            String authorizeUrl,
+                            HttpMethod authorizeMethod,
+                            List<String> scope,
                             String redirectUrl,
                             String grantType,
                             HttpMethod tokenMethod,
@@ -16,6 +22,9 @@ public record OAuthProvider(String name,
                 provider.getName(),
                 client.getId(),
                 client.getSecret(),
+                provider.getAuthorize().getUrl(),
+                HttpMethod.valueOf(provider.getAuthorize().getMethod()),
+                new ArrayList<>(client.getScopes()),
                 client.getRedirectUrl(),
                 provider.getToken().getIssue().getGrant_type(),
                 HttpMethod.valueOf(provider.getToken().getIssue().getMethod()),

--- a/src/test/java/org/chzzk/howmeet/domain/regular/member/service/MemberServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/member/service/MemberServiceTest.java
@@ -40,7 +40,7 @@ class MemberServiceTest {
         final MemberSummaryResponse expect = MemberSummaryResponse.from(memberSummaryDto);
 
         // when
-        doReturn(Optional.of(memberSummaryDto)).when(memberFindService).findSummary(authPrincipal.id());
+        doReturn(Optional.of(memberSummaryDto)).when(memberFindService).findSummaryByMemberId(authPrincipal.id());
         final MemberSummaryResponse actual = memberService.getSummary(authPrincipal);
 
         // then
@@ -54,7 +54,7 @@ class MemberServiceTest {
         final AuthPrincipal authPrincipal = AuthPrincipal.from(member);
 
         // when
-        doReturn(Optional.empty()).when(memberFindService).findSummary(authPrincipal.id());
+        doReturn(Optional.empty()).when(memberFindService).findSummaryByMemberId(authPrincipal.id());
 
         // then
         assertThatThrownBy(() -> memberService.getSummary(authPrincipal))

--- a/src/test/java/org/chzzk/howmeet/domain/regular/member/service/MemberServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/member/service/MemberServiceTest.java
@@ -6,7 +6,6 @@ import org.chzzk.howmeet.domain.regular.member.dto.summary.dto.MemberSummaryDto;
 import org.chzzk.howmeet.domain.regular.member.dto.summary.response.MemberSummaryResponse;
 import org.chzzk.howmeet.domain.regular.member.entity.Member;
 import org.chzzk.howmeet.domain.regular.member.exception.MemberException;
-import org.chzzk.howmeet.domain.regular.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,7 +24,7 @@ import static org.mockito.Mockito.doReturn;
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
     @Mock
-    MemberRepository memberRepository;
+    MemberFindService memberFindService;
 
     @InjectMocks
     MemberService memberService;
@@ -41,7 +40,7 @@ class MemberServiceTest {
         final MemberSummaryResponse expect = MemberSummaryResponse.from(memberSummaryDto);
 
         // when
-        doReturn(Optional.of(memberSummaryDto)).when(memberRepository).findSummaryById(authPrincipal.id());
+        doReturn(Optional.of(memberSummaryDto)).when(memberFindService).findSummary(authPrincipal.id());
         final MemberSummaryResponse actual = memberService.getSummary(authPrincipal);
 
         // then
@@ -55,7 +54,7 @@ class MemberServiceTest {
         final AuthPrincipal authPrincipal = AuthPrincipal.from(member);
 
         // when
-        doReturn(Optional.empty()).when(memberRepository).findSummaryById(authPrincipal.id());
+        doReturn(Optional.empty()).when(memberFindService).findSummary(authPrincipal.id());
 
         // then
         assertThatThrownBy(() -> memberService.getSummary(authPrincipal))


### PR DESCRIPTION
## 작업 내용
- 인가 코드 발급에 필요한 데이터를 제공하는 API 추가
- `OAuthResultHandler.saveOrGet()` 메서드 트랜잭션 최소화
  - `MemberFindService()` 추가
  - `MemberSaveService()` 추가
- `MemberService.getSummary()` 메서드 트랜잭션 최소화
  - `MemberFindService()` 사용


## 테스트
### Repository
<img width="554" alt="image" src="https://github.com/user-attachments/assets/dcc5e507-118d-4fb2-b052-a22eccb71688">


### Service
__RegularAuthService__
<img width="556" alt="image" src="https://github.com/user-attachments/assets/06a987bc-9957-43e2-aa82-e8fab95a80de">

__MemberService__
<img width="585" alt="image" src="https://github.com/user-attachments/assets/0cf27771-2aec-430c-9dda-6e6b4ae24b0d">

### Controller
__간단 정보 표시__
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/4199f00b-1d41-486d-9b65-707bb4ca1a0a">

__인가 코드 API (카카오)__
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/4abbf22d-21ae-4d36-a04e-a40486c9dcc3">

__인가 코드 API (네이버)__
<img width="1250" alt="image" src="https://github.com/user-attachments/assets/7a3f7af8-3623-483d-80ac-d1793b8de679">

__인가 코드 API (구글)__
<img width="1247" alt="image" src="https://github.com/user-attachments/assets/8f49a528-f137-4897-9220-d914737dbb31">

__인가 코드 API 실패 (소셜 이름이 잘못된 경우)__
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/93e4d942-e679-4028-aec2-7491f6ec19a2">

__인가 코드 API 실패 (소셜 이름이 없거나 공백인 경우)__
<img width="1249" alt="image" src="https://github.com/user-attachments/assets/9db21d32-7427-4eb7-996a-eb72605a2cef">


## 기타 사항 (참고 자료, 문의 사항 등)
- `application-oauth.yml` 이 변경되었습니다! 카톡으로 보내드릴테니 PR 병합 후 yml 파일도 반영해주세요!
- 트랜잭션 최소화는 #39 를 참고해주세요!
