### PR TITLE
[문서 추가] 결과 기능 api 문서 작업

### DIFF
--- a/src/main/java/org/chzzk/howmeet/domain/common/model/Nicknames.java
+++ b/src/main/java/org/chzzk/howmeet/domain/common/model/Nicknames.java
@@ -33,6 +33,10 @@ public class Nicknames {
         this.nicknames.addAll(nickNameSet);
     }
 
+//    public List<Nickname> getNicknames(){
+//        return List.copyOf(nicknames);
+//    }
+
     public static Nicknames convertNicknameProvidersList(final List<? extends NicknameProvider> nicknameProviders) {
         Nicknames nicknames = Nicknames.create();
 
@@ -40,5 +44,12 @@ public class Nicknames {
             nicknames.add(provider.getNickname());
         }
         return nicknames;
+    }
+
+    @JsonValue
+    public List<String> toJson() {
+        return List.copyOf(nicknames).stream()
+                .map(Nickname::getValue) // 각 Nickname 객체의 value 값을 추출
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/record/dto/get/MSRecordGetResponse.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/record/dto/get/MSRecordGetResponse.java
@@ -6,10 +6,10 @@ import org.chzzk.howmeet.domain.common.model.SelectionDetail;
 import org.chzzk.howmeet.domain.regular.room.model.RoomName;
 
 public record MSRecordGetResponse(Long msId, RoomName roomName, Nicknames totalPersonnel,
-                                  Nicknames participatedPersonnel, List<SelectionDetail> selectTime) {
+                                  Nicknames participatedPersonnel, List<SelectionDetail> time) {
 
     public static MSRecordGetResponse of(final Long msId, final RoomName roomName, final Nicknames totalPersonnel,
-            final Nicknames participatedPersonnel, final List<SelectionDetail> selectTime) {
-        return new MSRecordGetResponse(msId, roomName, totalPersonnel, participatedPersonnel, selectTime);
+            final Nicknames participatedPersonnel, final List<SelectionDetail> time) {
+        return new MSRecordGetResponse(msId, roomName, totalPersonnel, participatedPersonnel, time);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/record/dto/get/response/GSRecordGetResponse.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/record/dto/get/response/GSRecordGetResponse.java
@@ -5,10 +5,10 @@ import org.chzzk.howmeet.domain.common.model.Nicknames;
 import org.chzzk.howmeet.domain.common.model.SelectionDetail;
 
 public record GSRecordGetResponse(Long gsId, Nicknames totalPersonnel, Nicknames participatedPersonnel,
-                                  List<SelectionDetail> selectTime) {
+                                  List<SelectionDetail> time) {
 
     public static GSRecordGetResponse of(final Long gsId, final Nicknames totalPersonnel,
-            final Nicknames participatedPersonnel, final List<SelectionDetail> selectTime) {
-        return new GSRecordGetResponse(gsId, totalPersonnel, participatedPersonnel, selectTime);
+            final Nicknames participatedPersonnel, final List<SelectionDetail> time) {
+        return new GSRecordGetResponse(gsId, totalPersonnel, participatedPersonnel, time);
     }
 }

--- a/src/test/java/org/chzzk/howmeet/domain/regular/record/controller/MSReordControllerTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/record/controller/MSReordControllerTest.java
@@ -1,0 +1,134 @@
+package org.chzzk.howmeet.domain.regular.record.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
+import org.chzzk.howmeet.domain.regular.record.dto.get.MSRecordGetResponse;
+import org.chzzk.howmeet.domain.regular.record.dto.post.MSRecordPostRequest;
+import org.chzzk.howmeet.domain.regular.record.service.MSRecordService;
+import org.chzzk.howmeet.fixture.MSRecordFixture;
+import org.chzzk.howmeet.fixture.MemberFixture;
+import org.chzzk.howmeet.global.config.ControllerTest;
+import org.chzzk.howmeet.global.resolver.AuthPrincipalResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ControllerTest
+public class MSReordControllerTest {
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MSRecordService msRecordService;
+
+    @MockBean
+    private AuthPrincipalResolver resolver;
+
+    void setup() {
+        createAuthPrincipal();
+    }
+
+    private AuthPrincipal createAuthPrincipal() {
+        Member member = MemberFixture.KIM.생성();
+        return new AuthPrincipal(1L, member.getNickname().getValue(), member.getRole());
+    }
+
+    @Test
+    @DisplayName("회원 일정 조율: 일정 생성 테스트")
+    void createMSRecord() throws Exception {
+        Member member = MemberFixture.KIM.생성();
+        MSRecordPostRequest request = MSRecordFixture.createMSRecordPostRequestA();
+        AuthPrincipal authPrincipal = new AuthPrincipal(1L, member.getNickname().getValue(), member.getRole());
+
+        doNothing().when(msRecordService).postMSRecord(any(MSRecordPostRequest.class), any(AuthPrincipal.class));
+
+
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/ms-record")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .principal(() -> String.valueOf(authPrincipal))
+        );
+
+
+        // then
+        result.andExpect(status().isCreated());
+
+        // restdocs
+        result.andDo(document("회원 일정 조율: 일정 생성",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("msId").type(NUMBER).description("일정 ID"),
+                        fieldWithPath("selectTime[]").type(ARRAY).description("선택한 시간 목록")
+                )
+        ));
+    }
+
+
+    @Test
+    @DisplayName("회원 일정 조율: 회원 일정 리스트 get요청")
+    void getMSRecord() throws Exception {
+        // given
+        Long roomId = 1L;
+        Long msId = 1L;
+        Member member = MemberFixture.KIM.생성();
+        MSRecordGetResponse msRecordGetResponse = MSRecordFixture.createMSRecordGetResponseA();
+        AuthPrincipal authPrincipal = new AuthPrincipal(1L, member.getNickname().getValue(), member.getRole());
+
+        given(msRecordService.getMSRecord(eq(roomId), eq(msId), any(AuthPrincipal.class)))
+                .willReturn(msRecordGetResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/ms-record/{roomId}/{msId}", roomId, msId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .principal(() -> String.valueOf(authPrincipal))
+
+        );
+
+        // then
+        result.andExpect(status().isOk());
+
+        // restdocs
+        result.andDo(document("회원 일정 조율: 회원 일정 조회",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("roomId").description("방 ID"),
+                        parameterWithName("msId").description("일정 ID")
+                ),
+                responseFields(
+                        fieldWithPath("msId").type(NUMBER).description("일정 ID"),
+                        fieldWithPath("roomName").type(STRING).description("방 이름"),
+                        fieldWithPath("totalPersonnel").type(ARRAY).description("총 인원들의 닉네임 리스트"),
+//                        fieldWithPath("totalPersonnel.nicknames[].value").type(STRING).description("총 인원 중 하나의 닉네임"),
+                        fieldWithPath("participatedPersonnel").type(ARRAY).description("참여 인원들의 닉네임 리스트"),
+//                        fieldWithPath("participatedPersonnel.nicknames[].value").type(STRING).description("참여 인원 중 하나의 닉네임"),
+                        fieldWithPath("time[].selectTime").type(STRING).description("선택된 시간"),
+                        fieldWithPath("time[].participantDetails.count").type(NUMBER).description("참여자 수"),
+                        fieldWithPath("time[].participantDetails.nicknames").type(ARRAY).description("참여한 사람들의 닉네임")
+                )
+        ));
+    }
+}

--- a/src/test/java/org/chzzk/howmeet/domain/regular/record/repository/MSRecordRepositoryTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/record/repository/MSRecordRepositoryTest.java
@@ -12,15 +12,12 @@ import org.chzzk.howmeet.domain.regular.schedule.entity.MemberSchedule;
 import org.chzzk.howmeet.fixture.MSFixture;
 import org.chzzk.howmeet.fixture.MemberFixture;
 import org.chzzk.howmeet.fixture.RoomFixture;
-import org.chzzk.howmeet.global.config.TestConfig;
+import org.chzzk.howmeet.global.config.RepositoryTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(TestConfig.class)
+@RepositoryTest
 public class MSRecordRepositoryTest {
 
     @Autowired

--- a/src/test/java/org/chzzk/howmeet/domain/regular/record/service/MSRecordServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/record/service/MSRecordServiceTest.java
@@ -138,7 +138,7 @@ public class MSRecordServiceTest {
                 msRecordGetResponse.totalPersonnel().contains(member.getNickname()));
         assertTrue("참여 인원에 회원 닉네임이 포함되어 있지 않습니다.",
                 msRecordGetResponse.participatedPersonnel().contains(member.getNickname()));
-        assertFalse("선택 시간 목록이 비어있습니다.", msRecordGetResponse.selectTime().isEmpty());
+        assertFalse("선택 시간 목록이 비어있습니다.", msRecordGetResponse.time().isEmpty());
 
     }
 

--- a/src/test/java/org/chzzk/howmeet/domain/regular/record/service/MSRecordServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/record/service/MSRecordServiceTest.java
@@ -69,14 +69,9 @@ public class MSRecordServiceTest {
         AuthPrincipal authPrincipal = new AuthPrincipal(1L, member.getNickname().getValue(), member.getRole());
 
         when(msRepository.findById(memberSchedule.getId())).thenReturn(Optional.of(memberSchedule));
-        when(memberRepository.findById(anyLong())).thenAnswer(invocation -> {
-            Long id = invocation.getArgument(0);
-            return Optional.of(Member.of("김민우", "Kim", "123"));
-        });
-
         msRecordService.postMSRecord(msRecordPostRequest, authPrincipal);
 
-        verify(msRecordRepository).deleteByMemberScheduleIdAndMemberId(memberSchedule.getId(), member.getId());
+        verify(msRecordRepository).deleteByMemberScheduleIdAndMemberId(1L, 1L);
         verify(msRecordRepository).saveAll(anyList());
     }
 
@@ -95,11 +90,6 @@ public class MSRecordServiceTest {
         AuthPrincipal authPrincipal = new AuthPrincipal(1L, member.getNickname().getValue(), member.getRole());
 
         when(msRepository.findById(memberSchedule.getId())).thenReturn(Optional.of(memberSchedule));
-        when(memberRepository.findById(anyLong())).thenAnswer(invocation -> {
-            Long id = invocation.getArgument(0);
-            return Optional.of(Member.of("김민우", "Kim", "123"));
-        });
-
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             msRecordService.postMSRecord(msRecordPostRequest, authPrincipal);
         });
@@ -141,6 +131,4 @@ public class MSRecordServiceTest {
         assertFalse("선택 시간 목록이 비어있습니다.", msRecordGetResponse.time().isEmpty());
 
     }
-
-
 }

--- a/src/test/java/org/chzzk/howmeet/domain/temporary/record/controller/GSRecordControllerTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/temporary/record/controller/GSRecordControllerTest.java
@@ -1,0 +1,124 @@
+package org.chzzk.howmeet.domain.temporary.record.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
+import org.chzzk.howmeet.domain.temporary.auth.entity.Guest;
+import org.chzzk.howmeet.domain.temporary.record.dto.get.response.GSRecordGetResponse;
+import org.chzzk.howmeet.domain.temporary.record.dto.post.request.GSRecordPostRequest;
+import org.chzzk.howmeet.domain.temporary.record.service.GSRecordService;
+import org.chzzk.howmeet.fixture.GSRecordFixture;
+import org.chzzk.howmeet.fixture.GuestFixture;
+import org.chzzk.howmeet.global.config.ControllerTest;
+import org.chzzk.howmeet.global.resolver.AuthPrincipalResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ControllerTest
+public class GSRecordControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GSRecordService gsRecordService;
+
+    @MockBean
+    private AuthPrincipalResolver resolver;
+
+    void setup() {
+        createAuthPrincipal();
+    }
+
+    private AuthPrincipal createAuthPrincipal() {
+        Guest guest = GuestFixture.KIM.생성();
+        return new AuthPrincipal(1L, guest.getNickname().getValue(), guest.getRole());
+    }
+
+    @Test
+    @DisplayName("비회원 일정 조율: 일정 생성 테스트")
+    void createGSRecord() throws Exception {
+        Guest guest = GuestFixture.KIM.생성();
+        GSRecordPostRequest request = GSRecordFixture.createGSRecordPostRequestA();
+        AuthPrincipal authPrincipal = new AuthPrincipal(1L, guest.getNickname().getValue(), guest.getRole());
+
+        doNothing().when(gsRecordService).postGSRecord(any(GSRecordPostRequest.class), any(AuthPrincipal.class));
+
+
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/gs-record")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .principal(() -> String.valueOf(authPrincipal))
+        );
+
+
+        // then
+        result.andExpect(status().isCreated());
+
+        // restdocs
+        result.andDo(document("비회원 일정 조율: 일정 생성",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("gsId").type(NUMBER).description("일정 ID"),
+                        fieldWithPath("selectTime[]").type(ARRAY).description("선택한 시간 목록")
+                )
+        ));
+    }
+
+    @Test
+    @DisplayName("비회원 일정 조율: 회원 일정 리스트 get요청")
+    void getGSRecord() throws Exception {
+        // given
+        Long gsId = 1L;
+        GSRecordGetResponse gsRecordGetResponse = GSRecordFixture.createGSRecordGetResponseA();
+
+        given(gsRecordService.getGSRecord(eq(gsId)))
+                .willReturn(gsRecordGetResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/gs-record/{gsId}", gsId)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk());
+
+        // restdocs
+        result.andDo(document("비회원 일정 조율: 회원 일정 조회",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("gsId").description("일정 ID")
+                ),
+                responseFields(
+                        fieldWithPath("gsId").type(NUMBER).description("일정 ID"),
+                        fieldWithPath("totalPersonnel").type(ARRAY).description("총 인원들의 닉네임 리스트"),
+                        fieldWithPath("participatedPersonnel").type(ARRAY).description("참여 인원들의 닉네임 리스트"),
+                        fieldWithPath("time[].selectTime").type(STRING).description("선택된 시간"),
+                        fieldWithPath("time[].participantDetails.count").type(NUMBER).description("참여자 수"),
+                        fieldWithPath("time[].participantDetails.nicknames").type(ARRAY).description("참여한 사람들의 닉네임")
+                )
+        ));
+    }
+}

--- a/src/test/java/org/chzzk/howmeet/domain/temporary/record/repository/GSRecordRepositoryTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/temporary/record/repository/GSRecordRepositoryTest.java
@@ -11,15 +11,12 @@ import org.chzzk.howmeet.domain.temporary.schedule.repository.GSRepository;
 import org.chzzk.howmeet.fixture.GSFixture;
 import org.chzzk.howmeet.fixture.GSRecordFixture;
 import org.chzzk.howmeet.fixture.GuestFixture;
-import org.chzzk.howmeet.global.config.TestConfig;
+import org.chzzk.howmeet.global.config.RepositoryTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import(TestConfig.class)
+@RepositoryTest
 public class GSRecordRepositoryTest {
 
     @Autowired

--- a/src/test/java/org/chzzk/howmeet/domain/temporary/record/service/GSRecordServiceTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/temporary/record/service/GSRecordServiceTest.java
@@ -123,7 +123,7 @@ public class GSRecordServiceTest {
         assertEquals(gsId, gsRecordGetResponse.gsId(), "GS ID가 일치하지 않습니다.");
         assertTrue("총 인원에 회원 닉네임이 포함되어 있지 않습니다.", gsRecordGetResponse.totalPersonnel().contains(guest.getNickname()));
         assertTrue("참여 인원에 회원 닉네임이 포함되어 있지 않습니다.", gsRecordGetResponse.participatedPersonnel().contains(guest.getNickname()));
-        assertFalse("선택 시간 목록이 비어있습니다.", gsRecordGetResponse.selectTime().isEmpty());
+        assertFalse("선택 시간 목록이 비어있습니다.", gsRecordGetResponse.time().isEmpty());
 
     }
 }

--- a/src/test/java/org/chzzk/howmeet/fixture/GSRecordFixture.java
+++ b/src/test/java/org/chzzk/howmeet/fixture/GSRecordFixture.java
@@ -4,9 +4,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.chzzk.howmeet.domain.common.model.EncodedPassword;
 import org.chzzk.howmeet.domain.common.model.Nickname;
+import org.chzzk.howmeet.domain.common.model.Nicknames;
+import org.chzzk.howmeet.domain.common.model.SelectionDetail;
+import org.chzzk.howmeet.domain.regular.record.dto.get.MSRecordGetResponse;
+import org.chzzk.howmeet.domain.regular.record.dto.post.MSRecordPostRequest;
+import org.chzzk.howmeet.domain.regular.room.model.RoomName;
 import org.chzzk.howmeet.domain.temporary.auth.entity.Guest;
+import org.chzzk.howmeet.domain.temporary.record.dto.get.response.GSRecordGetResponse;
+import org.chzzk.howmeet.domain.temporary.record.dto.post.request.GSRecordPostRequest;
 import org.chzzk.howmeet.domain.temporary.record.entity.GuestScheduleRecord;
 import org.chzzk.howmeet.domain.temporary.schedule.entity.GuestSchedule;
 
@@ -32,10 +43,39 @@ public enum GSRecordFixture {
 
     private static Guest createMockGuest() {
         Guest guest = mock(Guest.class);
-        when(guest.getId()).thenReturn(1L); // 원하는 ID 값 설정
-        when(guest.getNickname()).thenReturn(Nickname.from("김민우"));
-        when(guest.getPassword()).thenReturn(EncodedPassword.from("123testpassword"));
+//        when(guest.getId()).thenReturn(1L); // 원하는 ID 값 설정
+//        when(guest.getNickname()).thenReturn(Nickname.from("김민우"));
+//        when(guest.getPassword()).thenReturn(EncodedPassword.from("123testpassword"));
         return guest;
+    }
+
+    public static GSRecordGetResponse createGSRecordGetResponseA() {
+        // 총 인원 닉네임 설정
+        Nicknames totalPersonnel = Nicknames.create();
+        totalPersonnel.add(Nickname.from("김민우"));
+        totalPersonnel.add(Nickname.from("이수진"));
+
+        // 참여 인원 닉네임 설정
+        Nicknames participatedPersonnel = Nicknames.create();
+        participatedPersonnel.add(Nickname.from("김민우"));
+
+        // 선택된 시간과 참여자 정보 설정
+        Map<LocalDateTime, Nicknames> selectTimeMap = new HashMap<>();
+        selectTimeMap.put(LocalDateTime.of(2023, 1, 1, 10, 30), participatedPersonnel);
+        List<SelectionDetail> time = SelectionDetail.convertMapToSelectionDetailsList(selectTimeMap);
+
+        // MSRecordGetResponse 객체 생성 및 반환
+        return GSRecordGetResponse.of(1L, totalPersonnel, participatedPersonnel, time);
+    }
+
+    public static GSRecordPostRequest createGSRecordPostRequestA() {
+        List<LocalDateTime> selectTimes = Arrays.asList(
+                LocalDateTime.of(2023, 1, 1, 10, 30),
+                LocalDateTime.of(2023, 1, 1, 11, 0),
+                LocalDateTime.of(2023, 1, 1, 11, 30)
+        );
+
+        return new GSRecordPostRequest(1L, selectTimes);
     }
 
     public GuestScheduleRecord CREATE() {

--- a/src/test/java/org/chzzk/howmeet/fixture/MSRecordFixture.java
+++ b/src/test/java/org/chzzk/howmeet/fixture/MSRecordFixture.java
@@ -1,0 +1,82 @@
+package org.chzzk.howmeet.fixture;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.chzzk.howmeet.domain.common.auth.model.Role;
+import org.chzzk.howmeet.domain.common.model.Image;
+import org.chzzk.howmeet.domain.common.model.Nickname;
+import org.chzzk.howmeet.domain.common.model.Nicknames;
+import org.chzzk.howmeet.domain.common.model.SelectionDetail;
+import org.chzzk.howmeet.domain.regular.member.entity.Member;
+import org.chzzk.howmeet.domain.regular.record.dto.get.MSRecordGetResponse;
+import org.chzzk.howmeet.domain.regular.record.dto.post.MSRecordPostRequest;
+import org.chzzk.howmeet.domain.regular.record.entity.MemberScheduleRecord;
+import org.chzzk.howmeet.domain.regular.room.model.RoomName;
+import org.chzzk.howmeet.domain.regular.schedule.entity.MemberSchedule;
+
+
+public enum MSRecordFixture {
+
+    KIM_MSRECORD_A(MSFixture.createMemberScheduleA(RoomFixture.createRoomA()), createMockMember(), LocalDateTime.of(2023, 1, 1, 10, 30, 0));
+
+    private final Member member;
+    private final MemberSchedule ms;
+    private final LocalDateTime selectTime;
+
+    MSRecordFixture(final MemberSchedule ms, final Member member, final LocalDateTime selectTime) {
+        this.ms = ms;
+        this.member = member;
+        this.selectTime = selectTime;
+    }
+
+    private static Member createMockMember() {
+        Member member = mock(Member.class);
+//        when(member.getId()).thenReturn(1L); // 원하는 ID 값 설정
+//        when(member.getNickname()).thenReturn(Nickname.from("김민우")); // 닉네임 설정
+//        when(member.getRole()).thenReturn(Role.REGULAR); // 역할 설정
+//        when(member.getProfileImage()).thenReturn(Image.from("https://example.com/profile.jpg")); // 프로필 이미지 설정
+//        when(member.getSocialId()).thenReturn("social12345"); // 소셜 ID 설정
+        return member;
+    }
+
+    public static MSRecordPostRequest createMSRecordPostRequestA() {
+        List<LocalDateTime> selectTimes = Arrays.asList(
+                LocalDateTime.of(2023, 1, 1, 10, 30),
+                LocalDateTime.of(2023, 1, 1, 11, 0),
+                LocalDateTime.of(2023, 1, 1, 11, 30)
+        );
+
+        return new MSRecordPostRequest(1L, selectTimes);
+    }
+    public static MSRecordGetResponse createMSRecordGetResponseA() {
+        RoomName roomName = RoomName.from("회의실 A");  // 방 이름 예시
+
+        // 총 인원 닉네임 설정
+        Nicknames totalPersonnel = Nicknames.create();
+        totalPersonnel.add(Nickname.from("김민우"));
+        totalPersonnel.add(Nickname.from("이수진"));
+
+        // 참여 인원 닉네임 설정
+        Nicknames participatedPersonnel = Nicknames.create();
+        participatedPersonnel.add(Nickname.from("김민우"));
+
+        // 선택된 시간과 참여자 정보 설정
+        Map<LocalDateTime, Nicknames> selectTimeMap = new HashMap<>();
+        selectTimeMap.put(LocalDateTime.of(2023, 1, 1, 10, 30), participatedPersonnel);
+        List<SelectionDetail> time = SelectionDetail.convertMapToSelectionDetailsList(selectTimeMap);
+
+        // MSRecordGetResponse 객체 생성 및 반환
+        return MSRecordGetResponse.of(1L, roomName, totalPersonnel, participatedPersonnel, time);
+    }
+
+
+    public MemberScheduleRecord create() {
+        return MemberScheduleRecord.of(this.member.getId(), this.ms, this.selectTime);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- GSRecord, MSRecord 관련 API 문서 작업
- GSRecord, MSRecord 둘다 post 요청과 get 요청에 대해 문서 작업 진행했습니다.
- 일정 확정은 알림과 같이 작업 한 후 API 문서 작업해서 pr 보내겠습니다.
- 그전까진 일단 HW-115 브랜치 유지하겠습니다.

## controller
<img width="930" alt="image" src="https://github.com/user-attachments/assets/8e03659c-20d7-4fb5-ae84-c3aa27d7cea9">

<img width="922" alt="image" src="https://github.com/user-attachments/assets/c755f429-2edf-47a7-8e0e-bed240caf7cd">

<img width="922" alt="image" src="https://github.com/user-attachments/assets/7e31eba7-52ae-4b94-930b-ded026f40d4c">

<img width="923" alt="image" src="https://github.com/user-attachments/assets/74eaf487-9798-443b-9b68-e245a20eba1b">



## 기타 사항 (참고 자료, 문의 사항 등)
- https://chech2.github.io/swagger-ui/  로 API 문서 공유했습니다. 
- 헤더에 토큰추가해야 되는 부분이 빠져 있는데 일정 확정 관련 기능 API 문서 작성하면서 추가해놓겠습니다