### PR TITLE
[기능 추가] 방에 속한 회원 조회 API

### DIFF
--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/controller/RoomController.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/controller/RoomController.java
@@ -15,7 +15,6 @@ import java.util.List;
 @RestController
 public class RoomController {
     private final RoomService roomService;
-    private final RoomMemberService roomMemberService;
 
     @PostMapping
     public ResponseEntity<?> createRoom(@RequestBody final RoomRequest roomRequest) {
@@ -30,14 +29,6 @@ public class RoomController {
             @RequestBody final RoomRequest roomRequest) {
         final RoomResponse roomResponse = roomService.updateRoom(roomId, roomRequest);
         return ResponseEntity.ok(roomResponse);
-    }
-
-    @PatchMapping("/{roomId}/members")
-    public ResponseEntity<List<RoomMemberResponse>> updateRoomMembers(
-            @PathVariable Long roomId,
-            @RequestBody final List<RoomMemberRequest> roomMemberRequests) {
-        List<RoomMemberResponse> roomMemberResponses = roomMemberService.updateRoomMembers(roomId, roomMemberRequests);
-        return ResponseEntity.ok(roomMemberResponses);
     }
 
     @GetMapping("/{roomId}")
@@ -56,11 +47,5 @@ public class RoomController {
     public ResponseEntity<?> deleteRoom(@PathVariable Long roomId) {
         roomService.deleteRoom(roomId);
         return ResponseEntity.ok("Room successfully deleted");
-    }
-
-    @DeleteMapping("/{roomId}/members/{roomMemberId}")
-    public ResponseEntity<?> deleteRoomMember(@PathVariable Long roomId, @PathVariable Long roomMemberId) {
-        roomService.deleteRoomMember(roomId, roomMemberId);
-        return ResponseEntity.ok("RoomMember successfully deleted");
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberController.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberController.java
@@ -27,8 +27,8 @@ public class RoomMemberController {
 
     @GetMapping
     @RegularUser
-    public ResponseEntity<?> get(@Authenticated final AuthPrincipal authPrincipal,
-                                 @PathVariable(name = "roomId") final Long roomId) {
+    public ResponseEntity<?> getRoomMember(@Authenticated final AuthPrincipal authPrincipal,
+                                           @PathVariable(name = "roomId") final Long roomId) {
         final RoomMemberGetResponse roomMemberGetResponse = roomMemberService.get(authPrincipal, roomId);
         return ResponseEntity.ok(roomMemberGetResponse);
     }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberController.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberController.java
@@ -29,7 +29,7 @@ public class RoomMemberController {
     @RegularUser
     public ResponseEntity<?> getRoomMember(@Authenticated final AuthPrincipal authPrincipal,
                                            @PathVariable(name = "roomId") final Long roomId) {
-        final RoomMemberGetResponse roomMemberGetResponse = roomMemberService.get(authPrincipal, roomId);
+        final RoomMemberGetResponse roomMemberGetResponse = roomMemberService.getRoomMember(authPrincipal, roomId);
         return ResponseEntity.ok(roomMemberGetResponse);
     }
 

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberController.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberController.java
@@ -1,0 +1,47 @@
+package org.chzzk.howmeet.domain.regular.room.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.common.auth.annotation.Authenticated;
+import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
+import org.chzzk.howmeet.domain.regular.auth.annotation.RegularUser;
+import org.chzzk.howmeet.domain.regular.room.dto.RoomMemberRequest;
+import org.chzzk.howmeet.domain.regular.room.dto.RoomMemberResponse;
+import org.chzzk.howmeet.domain.regular.room.dto.get.response.RoomMemberGetResponse;
+import org.chzzk.howmeet.domain.regular.room.service.RoomMemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController("/room/{roomId}/members")
+public class RoomMemberController {
+    private final RoomMemberService roomMemberService;
+
+    @GetMapping
+    @RegularUser
+    public ResponseEntity<?> get(@Authenticated final AuthPrincipal authPrincipal,
+                                 @PathVariable("roomId") final Long roomId) {
+        final RoomMemberGetResponse roomMemberGetResponse = roomMemberService.get(authPrincipal, roomId);
+        return ResponseEntity.ok(roomMemberGetResponse);
+    }
+
+    @DeleteMapping("/{roomMemberId}")
+    public ResponseEntity<?> deleteRoomMember(@PathVariable Long roomId, @PathVariable Long roomMemberId) {
+        roomMemberService.deleteRoomMember(roomId, roomMemberId);
+        return ResponseEntity.ok("RoomMember successfully deleted");
+    }
+
+    @PatchMapping
+    public ResponseEntity<List<RoomMemberResponse>> updateRoomMembers(
+            @PathVariable Long roomId,
+            @RequestBody final List<RoomMemberRequest> roomMemberRequests) {
+        List<RoomMemberResponse> roomMemberResponses = roomMemberService.updateRoomMembers(roomId, roomMemberRequests);
+        return ResponseEntity.ok(roomMemberResponses);
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberController.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberController.java
@@ -14,32 +14,35 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RequiredArgsConstructor
-@RestController("/room/{roomId}/members")
+@RequestMapping("/room/{roomId}/members")
+@RestController
 public class RoomMemberController {
     private final RoomMemberService roomMemberService;
 
     @GetMapping
     @RegularUser
     public ResponseEntity<?> get(@Authenticated final AuthPrincipal authPrincipal,
-                                 @PathVariable("roomId") final Long roomId) {
+                                 @PathVariable(name = "roomId") final Long roomId) {
         final RoomMemberGetResponse roomMemberGetResponse = roomMemberService.get(authPrincipal, roomId);
         return ResponseEntity.ok(roomMemberGetResponse);
     }
 
     @DeleteMapping("/{roomMemberId}")
-    public ResponseEntity<?> deleteRoomMember(@PathVariable Long roomId, @PathVariable Long roomMemberId) {
+    public ResponseEntity<?> deleteRoomMember(@PathVariable(name = "roomId") Long roomId,
+                                              @PathVariable(name = "roomMemberId") Long roomMemberId) {
         roomMemberService.deleteRoomMember(roomId, roomMemberId);
         return ResponseEntity.ok("RoomMember successfully deleted");
     }
 
     @PatchMapping
     public ResponseEntity<List<RoomMemberResponse>> updateRoomMembers(
-            @PathVariable Long roomId,
+            @PathVariable(name = "roomId") Long roomId,
             @RequestBody final List<RoomMemberRequest> roomMemberRequests) {
         List<RoomMemberResponse> roomMemberResponses = roomMemberService.updateRoomMembers(roomId, roomMemberRequests);
         return ResponseEntity.ok(roomMemberResponses);

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/dto/get/response/RoomMemberGetResponse.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/dto/get/response/RoomMemberGetResponse.java
@@ -1,0 +1,9 @@
+package org.chzzk.howmeet.domain.regular.room.dto.get.response;
+
+import org.chzzk.howmeet.domain.regular.room.entity.RoomMember;
+
+public record RoomMemberGetResponse(Boolean isLeader) {
+    public static RoomMemberGetResponse from(final RoomMember roomMember) {
+        return new RoomMemberGetResponse(roomMember.getIsLeader());
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/repository/RoomMemberRepository.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/repository/RoomMemberRepository.java
@@ -2,10 +2,13 @@ package org.chzzk.howmeet.domain.regular.room.repository;
 
 import org.chzzk.howmeet.domain.regular.room.entity.RoomMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
     List<RoomMember> findByRoomId(final Long roomId);
     List<RoomMember> findByMemberId(final Long memberId);
+    Optional<RoomMember> findByRoomIdAndMemberId(@Param("roomId") final Long roomId, @Param("memberId") final Long memberId);
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/service/RoomMemberService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/service/RoomMemberService.java
@@ -28,7 +28,7 @@ public class RoomMemberService {
     private final RoomMemberRepository roomMemberRepository;
     private final RoomRepository roomRepository;
 
-    public RoomMemberGetResponse get(final AuthPrincipal authPrincipal, final Long roomId) {
+    public RoomMemberGetResponse getRoomMember(final AuthPrincipal authPrincipal, final Long roomId) {
         final RoomMember roomMember = findRoomMemberByAuthAndRoomId(authPrincipal, roomId);
         return RoomMemberGetResponse.from(roomMember);
     }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/service/RoomMemberService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/service/RoomMemberService.java
@@ -1,10 +1,13 @@
 package org.chzzk.howmeet.domain.regular.room.service;
 
 import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
 import org.chzzk.howmeet.domain.regular.room.dto.RoomMemberRequest;
 import org.chzzk.howmeet.domain.regular.room.dto.RoomMemberResponse;
+import org.chzzk.howmeet.domain.regular.room.dto.get.response.RoomMemberGetResponse;
 import org.chzzk.howmeet.domain.regular.room.entity.Room;
 import org.chzzk.howmeet.domain.regular.room.entity.RoomMember;
+import org.chzzk.howmeet.domain.regular.room.exception.RoomException;
 import org.chzzk.howmeet.domain.regular.room.exception.RoomMemberException;
 import org.chzzk.howmeet.domain.regular.room.repository.RoomMemberRepository;
 import org.chzzk.howmeet.domain.regular.room.repository.RoomRepository;
@@ -14,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.chzzk.howmeet.domain.regular.room.exception.RoomErrorCode.INVALID_ROOM_MEMBER;
+import static org.chzzk.howmeet.domain.regular.room.exception.RoomErrorCode.ROOM_MEMBER_NOT_FOUND;
 import static org.chzzk.howmeet.domain.regular.room.exception.RoomMemberErrorCode.ROOM_NOT_FOUND;
 
 @RequiredArgsConstructor
@@ -22,6 +27,20 @@ import static org.chzzk.howmeet.domain.regular.room.exception.RoomMemberErrorCod
 public class RoomMemberService {
     private final RoomMemberRepository roomMemberRepository;
     private final RoomRepository roomRepository;
+
+    public RoomMemberGetResponse get(final AuthPrincipal authPrincipal, final Long roomId) {
+        final RoomMember roomMember = findRoomMemberByAuthAndRoomId(authPrincipal, roomId);
+        return RoomMemberGetResponse.from(roomMember);
+    }
+
+    @Transactional
+    public void deleteRoomMember(final Long roomId, final Long roomMemberId) {
+        RoomMember roomMember = findRoomMemberById(roomMemberId);
+        if (!roomMember.getRoom().getId().equals(roomId)) {
+            throw new RoomException(INVALID_ROOM_MEMBER);
+        }
+        roomMemberRepository.deleteById(roomMemberId);
+    }
 
     @Transactional
     public List<RoomMemberResponse> updateRoomMembers(final Long roomId, final List<RoomMemberRequest> roomMemberRequests) {
@@ -43,4 +62,15 @@ public class RoomMemberService {
         return roomRepository.findById(roomId)
                 .orElseThrow(() -> new RoomMemberException(ROOM_NOT_FOUND));
     }
+
+    private RoomMember findRoomMemberById(final Long roomMemberId) {
+        return roomMemberRepository.findById(roomMemberId)
+                .orElseThrow(() -> new RoomException(ROOM_MEMBER_NOT_FOUND));
+    }
+
+    private RoomMember findRoomMemberByAuthAndRoomId(final AuthPrincipal authPrincipal, final Long roomId) {
+        return roomMemberRepository.findByRoomIdAndMemberId(roomId, authPrincipal.id())
+                .orElseThrow(() -> new RoomMemberException(ROOM_NOT_FOUND));
+    }
+
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/service/RoomService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/service/RoomService.java
@@ -66,21 +66,6 @@ public class RoomService {
                 .collect(Collectors.toList());
     }
 
-    private RoomListResponse mapToRoomListResponse(RoomMember roomMember) {
-        Room room = roomMember.getRoom();
-        List<MemberSchedule> memberSchedules = room.getSchedules();
-
-        String leaderNickname = room.getMembers().stream()
-                .filter(RoomMember::getIsLeader)
-                .findFirst()
-                .map(leader -> memberRepository.findIdAndNicknameById(leader.getMemberId())
-                        .map(memberNicknameDto -> memberNicknameDto.nickname().getValue())
-                        .orElse(null))
-                .orElse(null);
-
-        return RoomListMapper.toRoomListResponse(room, memberSchedules, leaderNickname);
-    }
-
     @Transactional
     public RoomResponse updateRoom(final Long roomId, final RoomRequest roomRequest) {
         Room room = getRoomById(roomId);
@@ -99,14 +84,19 @@ public class RoomService {
         roomRepository.delete(room);
     }
 
-    @Transactional
-    public void deleteRoomMember(final Long roomId, final Long roomMemberId) {
-        RoomMember roomMember = roomMemberRepository.findById(roomMemberId)
-                .orElseThrow(() -> new RoomException(ROOM_MEMBER_NOT_FOUND));
-        if (!roomMember.getRoom().getId().equals(roomId)) {
-            throw new RoomException(INVALID_ROOM_MEMBER);
-        }
-        roomMemberRepository.deleteById(roomMemberId);
+    private RoomListResponse mapToRoomListResponse(RoomMember roomMember) {
+        Room room = roomMember.getRoom();
+        List<MemberSchedule> memberSchedules = room.getSchedules();
+
+        String leaderNickname = room.getMembers().stream()
+                .filter(RoomMember::getIsLeader)
+                .findFirst()
+                .map(leader -> memberRepository.findIdAndNicknameById(leader.getMemberId())
+                        .map(memberNicknameDto -> memberNicknameDto.nickname().getValue())
+                        .orElse(null))
+                .orElse(null);
+
+        return RoomListMapper.toRoomListResponse(room, memberSchedules, leaderNickname);
     }
 
     private Room getRoomById(Long roomId) {

--- a/src/test/java/org/chzzk/howmeet/domain/regular/room/controller/RoomControllerTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/room/controller/RoomControllerTest.java
@@ -43,9 +43,6 @@ public class RoomControllerTest {
     @MockBean
     private RoomService roomService;
 
-    @MockBean
-    private RoomMemberService roomMemberService;
-
     @Test
     @DisplayName("방 생성 테스트")
     void createRoom() throws Exception {
@@ -135,44 +132,6 @@ public class RoomControllerTest {
         ));
     }
 
-    @Test
-    @DisplayName("방 멤버 업데이트 테스트")
-    void updateRoomMembers() throws Exception {
-        // given
-        Room room = RoomFixture.createRoomA();
-        List<RoomMemberRequest> roomMemberRequests = RoomMemberFixture.createRoomMemberRequests(room);
-        List<RoomMemberResponse> roomMemberResponses = RoomMemberFixture.createRoomMemberResponses(room);
-
-        given(roomMemberService.updateRoomMembers(any(Long.class), anyList())).willReturn(roomMemberResponses);
-
-        // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/room/{roomId}/members", 1L)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(roomMemberRequests))
-        );
-
-        // then
-        result.andExpect(status().isOk());
-
-        // restdocs
-        result.andDo(document("방 멤버 업데이트",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(
-                        parameterWithName("roomId").description("방 ID")
-                ),
-                requestFields(
-                        fieldWithPath("[].memberId").type(NUMBER).description("멤버 ID"),
-                        fieldWithPath("[].roomId").type(NUMBER).description("방 ID"),
-                        fieldWithPath("[].isLeader").type(BOOLEAN).description("리더 여부")
-                ),
-                responseFields(
-                        fieldWithPath("[].id").type(NUMBER).description("방 멤버 ID").optional(),
-                        fieldWithPath("[].memberId").type(NUMBER).description("멤버 ID"),
-                        fieldWithPath("[].isLeader").type(BOOLEAN).description("리더 여부")
-                )
-        ));
-    }
     @Test
     @DisplayName("방 조회 테스트")
     void getRoom() throws Exception {
@@ -281,31 +240,6 @@ public class RoomControllerTest {
                 preprocessResponse(prettyPrint()),
                 pathParameters(
                         parameterWithName("roomId").description("방 ID")
-                )
-        ));
-    }
-
-    @Test
-    @DisplayName("방 멤버 삭제 테스트")
-    void deleteRoomMember() throws Exception {
-        // given
-        willDoNothing().given(roomService).deleteRoomMember(any(Long.class), any(Long.class));
-
-        // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/room/{roomId}/members/{roomMemberId}", 1L, 1L)
-                .contentType(MediaType.APPLICATION_JSON)
-        );
-
-        // then
-        result.andExpect(status().isOk());
-
-        // restdocs
-        result.andDo(document("방 멤버 삭제",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(
-                        parameterWithName("roomId").description("방 ID"),
-                        parameterWithName("roomMemberId").description("방 멤버 ID")
                 )
         ));
     }

--- a/src/test/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberControllerTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberControllerTest.java
@@ -84,7 +84,7 @@ class RoomMemberControllerTest {
         final Room roomA = createRoomA();
         final RoomMember roomMember = MEMBER_1.create(roomA);
         final RoomMemberGetResponse expect = RoomMemberGetResponse.from(roomMember);
-        doReturn(expect).when(roomMemberService).get(any(), any());
+        doReturn(expect).when(roomMemberService).getRoomMember(any(), any());
 
         // when
         final ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/room/{roomId}/members", 1L)

--- a/src/test/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberControllerTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberControllerTest.java
@@ -79,7 +79,7 @@ class RoomMemberControllerTest {
 
     @Test
     @DisplayName("방 멤버 조회 테스트")
-    public void get() throws Exception {
+    public void getRoomMember() throws Exception {
         // given
         final Room roomA = createRoomA();
         final RoomMember roomMember = MEMBER_1.create(roomA);

--- a/src/test/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberControllerTest.java
+++ b/src/test/java/org/chzzk/howmeet/domain/regular/room/controller/RoomMemberControllerTest.java
@@ -1,0 +1,176 @@
+package org.chzzk.howmeet.domain.regular.room.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.chzzk.howmeet.domain.common.auth.model.AuthPrincipal;
+import org.chzzk.howmeet.domain.regular.room.dto.RoomMemberRequest;
+import org.chzzk.howmeet.domain.regular.room.dto.RoomMemberResponse;
+import org.chzzk.howmeet.domain.regular.room.dto.get.response.RoomMemberGetResponse;
+import org.chzzk.howmeet.domain.regular.room.entity.Room;
+import org.chzzk.howmeet.domain.regular.room.entity.RoomMember;
+import org.chzzk.howmeet.domain.regular.room.service.RoomMemberService;
+import org.chzzk.howmeet.global.config.ControllerTest;
+import org.chzzk.howmeet.global.interceptor.AuthenticationInterceptor;
+import org.chzzk.howmeet.global.interceptor.MemberAuthorityInterceptor;
+import org.chzzk.howmeet.global.resolver.AuthPrincipalResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static org.chzzk.howmeet.fixture.MemberFixture.KIM;
+import static org.chzzk.howmeet.fixture.RoomFixture.createRoomA;
+import static org.chzzk.howmeet.fixture.RoomMemberFixture.MEMBER_1;
+import static org.chzzk.howmeet.fixture.RoomMemberFixture.createRoomMemberRequests;
+import static org.chzzk.howmeet.fixture.RoomMemberFixture.createRoomMemberResponses;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ControllerTest
+class RoomMemberControllerTest {
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RoomMemberService roomMemberService;
+
+    @MockBean
+    AuthenticationInterceptor authenticationInterceptor;
+
+    @MockBean
+    MemberAuthorityInterceptor memberAuthorityInterceptor;
+
+    @MockBean
+    AuthPrincipalResolver authPrincipalResolver;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        doReturn(true).when(authenticationInterceptor).preHandle(any(), any(), any());
+        doReturn(true).when(memberAuthorityInterceptor).preHandle(any(), any(), any());
+        doReturn(AuthPrincipal.from(KIM.생성())).when(authPrincipalResolver).resolveArgument(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("방 멤버 조회 테스트")
+    public void get() throws Exception {
+        // given
+        final Room roomA = createRoomA();
+        final RoomMember roomMember = MEMBER_1.create(roomA);
+        final RoomMemberGetResponse expect = RoomMemberGetResponse.from(roomMember);
+        doReturn(expect).when(roomMemberService).get(any(), any());
+
+        // when
+        final ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/room/{roomId}/members", 1L)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer {ACCESS_TOKEN}")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk());
+
+        // restdocs
+        result.andDo(document("방 멤버 조회",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("roomId").description("방 ID")
+                ),
+                requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer 토큰")
+                ),
+                responseFields(
+                        fieldWithPath("isLeader").type(BOOLEAN).description("방장 여부")
+                )
+        ));
+    }
+
+    @Test
+    @DisplayName("방 멤버 업데이트 테스트")
+    void updateRoomMembers() throws Exception {
+        // given
+        Room room = createRoomA();
+        List<RoomMemberRequest> roomMemberRequests = createRoomMemberRequests(room);
+        List<RoomMemberResponse> roomMemberResponses = createRoomMemberResponses(room);
+
+        given(roomMemberService.updateRoomMembers(any(Long.class), anyList())).willReturn(roomMemberResponses);
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/room/{roomId}/members", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(roomMemberRequests))
+        );
+
+        // then
+        result.andExpect(status().isOk());
+
+        // restdocs
+        result.andDo(document("방 멤버 업데이트",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("roomId").description("방 ID")
+                ),
+                requestFields(
+                        fieldWithPath("[].memberId").type(NUMBER).description("멤버 ID"),
+                        fieldWithPath("[].roomId").type(NUMBER).description("방 ID"),
+                        fieldWithPath("[].isLeader").type(BOOLEAN).description("리더 여부")
+                ),
+                responseFields(
+                        fieldWithPath("[].id").type(NUMBER).description("방 멤버 ID").optional(),
+                        fieldWithPath("[].memberId").type(NUMBER).description("멤버 ID"),
+                        fieldWithPath("[].isLeader").type(BOOLEAN).description("리더 여부")
+                )
+        ));
+    }
+
+    @Test
+    @DisplayName("방 멤버 삭제 테스트")
+    void deleteRoomMember() throws Exception {
+        // given
+        willDoNothing().given(roomMemberService).deleteRoomMember(any(Long.class), any(Long.class));
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/room/{roomId}/members/{roomMemberId}", 1L, 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk());
+
+        // restdocs
+        result.andDo(document("방 멤버 삭제",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("roomId").description("방 ID"),
+                        parameterWithName("roomMemberId").description("방 멤버 ID")
+                )
+        ));
+    }
+}

--- a/src/test/java/org/chzzk/howmeet/global/config/ControllerTest.java
+++ b/src/test/java/org/chzzk/howmeet/global/config/ControllerTest.java
@@ -14,8 +14,7 @@ import java.lang.annotation.Target;
 
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
-@ExtendWith(RestDocumentationExtension.class)
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @SpringBootTest

--- a/src/test/java/org/chzzk/howmeet/global/config/RepositoryTest.java
+++ b/src/test/java/org/chzzk/howmeet/global/config/RepositoryTest.java
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest(showSql = false, includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Repository.class))
-@Import({TestJpaAuditingConfig.class, TestQueryDslConfig.class})
+@Import(TestQueryDslConfig.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @TestPropertySource(locations = "classpath:application-test.yml")

--- a/src/test/java/org/chzzk/howmeet/global/config/TestJpaAuditingConfig.java
+++ b/src/test/java/org/chzzk/howmeet/global/config/TestJpaAuditingConfig.java
@@ -1,9 +1,0 @@
-package org.chzzk.howmeet.global.config;
-
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@EnableJpaAuditing
-@TestConfiguration
-public class TestJpaAuditingConfig {
-}


### PR DESCRIPTION
## 작업 내용
- 방에 속한 회원 조회 API 추가
  - `RoomMemberController.get()`
  - 방 ID(`roomId`)와 엑세스 토큰을 통해 조회
- `RoomMemberControllerTest` 추가
- `@RepositoryTest` 에 `@TestJpaAuditingConfig` 속성 제거
  - `HowMeetApplication.main()` 메서드에 `@EnableJpaAuditing`이 있어 중첩 문제가 발생

## 테스트
### Repository
- 테스트 성공 내역을 캡쳐해서 업로드
### Service
- 테스트 성공 내역을 캡쳐해서 업로드
### Controller
- Postman 내역 캡쳐해서 업로드

## 기타 사항 (참고 자료, 문의 사항 등)
- 방의 속한 회원의 어떤 정보를 줘야되는지 몰라서 일단 방장 여부만 응답 Body에 포함시켰습니다! (`RoomMemberGetResponse` 필드 참고)  어떤 값이 필요한지 아시는 분든 댓글로 남겨주세요!
- 조회 시 DB에서 엔티티를 가져오고 이를 응답 DTO로 변환 (`RoomMemberGetResponse.from()`) 합니다. 응답에 필요한 컬럼만 DB에서 가져오는게 좋기때문에 추후 응답값이 확실시되면 수정하겠습니다. 왠만하면 DB에서 데이터를 가져올 때 엔티티가 아니라 필요한 컬럼만 가져오도록 하는게 좋을 것 같습니다.
- @SSUHYUNKIM 님이 작성하신 `RoomController`, `RoomMemberController`, `RoomService`, `RoomMemberService` 메서드명이 `updateRoom`, `deleteRoom` 이런식으로 행동 + 대상으로 되있습니다. 근데 대상이 클래스명에 포함되있으니 간단하게 `delete()`, `update()` 로 표현하는건 어떨까요?
