### PR TITLE
[기능 수정]  회원 일정 조회 출력 변경, 비회원 일정 생성시 응답값 수정

### DIFF
--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/dto/RoomCreateResponse.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/dto/RoomCreateResponse.java
@@ -1,9 +1,6 @@
 package org.chzzk.howmeet.domain.regular.room.dto;
 
 import org.chzzk.howmeet.domain.regular.room.entity.Room;
-import org.chzzk.howmeet.domain.regular.schedule.dto.MSResponse;
-
-import java.util.List;
 
 public record RoomCreateResponse(Long roomId) {
 

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/dto/RoomResponse.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/dto/RoomResponse.java
@@ -1,13 +1,9 @@
 package org.chzzk.howmeet.domain.regular.room.dto;
 
 import org.chzzk.howmeet.domain.regular.room.entity.Room;
-import org.chzzk.howmeet.domain.regular.room.entity.RoomMember;
 import org.chzzk.howmeet.domain.regular.schedule.dto.MSResponse;
-import org.chzzk.howmeet.domain.regular.schedule.entity.MemberSchedule;
-import org.chzzk.howmeet.domain.regular.schedule.entity.ScheduleStatus;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record RoomResponse(Long roomId,
                            String name,

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/service/RoomService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/service/RoomService.java
@@ -1,10 +1,11 @@
 package org.chzzk.howmeet.domain.regular.room.service;
 
 import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.common.embedded.date.impl.ScheduleTime;
 import org.chzzk.howmeet.domain.common.entity.BaseEntity;
-import org.chzzk.howmeet.domain.common.model.Nickname;
+import org.chzzk.howmeet.domain.regular.confirm.entity.ConfirmSchedule;
+import org.chzzk.howmeet.domain.regular.confirm.repository.ConfirmRepository;
 import org.chzzk.howmeet.domain.regular.member.dto.nickname.dto.MemberNicknameDto;
-import org.chzzk.howmeet.domain.regular.member.entity.Member;
 import org.chzzk.howmeet.domain.regular.member.repository.MemberRepository;
 import org.chzzk.howmeet.domain.regular.room.dto.*;
 import org.chzzk.howmeet.domain.regular.room.entity.Room;
@@ -13,13 +14,18 @@ import org.chzzk.howmeet.domain.regular.room.exception.RoomException;
 import org.chzzk.howmeet.domain.regular.room.repository.RoomMemberRepository;
 import org.chzzk.howmeet.domain.regular.room.repository.RoomRepository;
 import org.chzzk.howmeet.domain.regular.room.util.RoomListMapper;
+import org.chzzk.howmeet.domain.regular.schedule.dto.CompletedMSResponse;
 import org.chzzk.howmeet.domain.regular.schedule.dto.MSResponse;
+import org.chzzk.howmeet.domain.regular.schedule.dto.ProgressedMSResponse;
 import org.chzzk.howmeet.domain.regular.schedule.entity.MemberSchedule;
+import org.chzzk.howmeet.domain.regular.schedule.entity.ScheduleStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +40,7 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final RoomMemberRepository roomMemberRepository;
     private final MemberRepository memberRepository;
+    private final ConfirmRepository confirmRepository;
 
     @Transactional
     public RoomCreateResponse createRoom(final RoomRequest roomRequest) {
@@ -66,8 +73,18 @@ public class RoomService {
 
         List<MSResponse> schedules = room.getSchedules().stream()
                 .sorted(Comparator.comparing(BaseEntity::getCreatedAt))
-                .map(MSResponse::from)
-                .toList();
+                .map(memberSchedule -> {
+                    if (memberSchedule.getStatus() == ScheduleStatus.COMPLETE) {
+                        ConfirmSchedule confirmSchedule = findConfirmScheduleByMSId(memberSchedule.getId());
+                        List<LocalDateTime> confirmTimes = confirmSchedule.getTimes();
+                        List<String> dates = extractDatesFromConfirmTimes(confirmTimes);
+                        ScheduleTime scheduleTime = extractScheduleTimeFromConfirmTimes(confirmTimes);
+                        return CompletedMSResponse.of(memberSchedule, dates, scheduleTime);
+                    } else {
+                        return ProgressedMSResponse.from(memberSchedule);
+                    }
+                })
+                .collect(Collectors.toList());
 
         return RoomResponse.of(room, roomMemberResponses, schedules);
     }
@@ -112,7 +129,23 @@ public class RoomService {
                         .orElse(null))
                 .orElse(null);
 
-        return RoomListMapper.toRoomListResponse(room, memberSchedules, leaderNickname);
+        return RoomListMapper.toRoomListResponse(room, memberSchedules, leaderNickname, this::findConfirmScheduleByMSId);
+    }
+
+    private ConfirmSchedule findConfirmScheduleByMSId(Long memberScheduleId) {
+        return confirmRepository.findByMemberScheduleId(memberScheduleId)
+                .orElseThrow(() -> new IllegalArgumentException("일치하는 일정 결과를 찾을 수 없습니다."));
+    }
+
+    private List<String> extractDatesFromConfirmTimes(List<LocalDateTime> confirmTimes) {
+        String date = confirmTimes.get(0).toLocalDate().toString();
+        return List.of(date);
+    }
+
+    private ScheduleTime extractScheduleTimeFromConfirmTimes(List<LocalDateTime> confirmTimes) {
+        LocalTime startTime = confirmTimes.get(0).toLocalTime();
+        LocalTime endTime = confirmTimes.get(1).toLocalTime();
+        return ScheduleTime.of(startTime, endTime);
     }
 
     private Room getRoomById(Long roomId) {

--- a/src/main/java/org/chzzk/howmeet/domain/regular/room/util/RoomListMapper.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/room/util/RoomListMapper.java
@@ -1,35 +1,43 @@
 package org.chzzk.howmeet.domain.regular.room.util;
 
+import org.chzzk.howmeet.domain.common.embedded.date.impl.ScheduleTime;
 import org.chzzk.howmeet.domain.common.entity.BaseEntity;
+import org.chzzk.howmeet.domain.regular.confirm.entity.ConfirmSchedule;
 import org.chzzk.howmeet.domain.regular.room.dto.RoomListResponse;
 import org.chzzk.howmeet.domain.regular.room.entity.Room;
-import org.chzzk.howmeet.domain.regular.room.entity.RoomMember;
+import org.chzzk.howmeet.domain.regular.schedule.dto.CompletedMSResponse;
 import org.chzzk.howmeet.domain.regular.schedule.dto.MSResponse;
+import org.chzzk.howmeet.domain.regular.schedule.dto.ProgressedMSResponse;
 import org.chzzk.howmeet.domain.regular.schedule.entity.MemberSchedule;
 import org.chzzk.howmeet.domain.regular.schedule.entity.ScheduleStatus;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class RoomListMapper {
 
-    public static RoomListResponse toRoomListResponse(final Room room, final List<MemberSchedule> memberSchedules, String leaderNickname) {
+    public static RoomListResponse toRoomListResponse(final Room room, final List<MemberSchedule> memberSchedules, String leaderNickname, ConfirmScheduleFinder confirmScheduleFinder) {
         int totalMembers = room.getMembers().size();
 
-        Optional<RoomMember> leaderRoomMember = room.getMembers().stream()
-                .filter(RoomMember::getIsLeader)
-                .findFirst();
-
-        String memberSummary = totalMembers > 1
-                ? String.format("%s 외 %d명", leaderNickname, totalMembers - 1)
-                : "1명";
+        String memberSummary = String.format("%s 외 %d명", leaderNickname, totalMembers - 1);
 
         List<MSResponse> schedules = memberSchedules.stream()
-                .filter(schedule -> schedule.getStatus() == ScheduleStatus.PROGRESS)
                 .sorted(Comparator.comparing(BaseEntity::getCreatedAt))
-                .map(MSResponse::from)
+                .map(memberSchedule -> {
+                    if (memberSchedule.getStatus() == ScheduleStatus.COMPLETE) {
+                        ConfirmSchedule confirmSchedule = confirmScheduleFinder.findConfirmScheduleByMSId(memberSchedule.getId());
+                        List<LocalDateTime> confirmTimes = confirmSchedule.getTimes();
+                        List<String> dates = extractDatesFromConfirmTimes(confirmTimes);
+                        ScheduleTime scheduleTime = extractScheduleTimeFromConfirmTimes(confirmTimes);
+                        return CompletedMSResponse.of(memberSchedule, dates, scheduleTime);
+                    } else {
+                        return ProgressedMSResponse.from(memberSchedule);
+                    }
+                })
                 .collect(Collectors.toList());
 
         return new RoomListResponse(
@@ -38,5 +46,21 @@ public class RoomListMapper {
                 memberSummary,
                 schedules
         );
+    }
+
+    public interface ConfirmScheduleFinder {
+        ConfirmSchedule findConfirmScheduleByMSId(Long memberScheduleId);
+    }
+
+    private static List<String> extractDatesFromConfirmTimes(List<LocalDateTime> confirmTimes) {
+        String date = confirmTimes.get(0).toLocalDate().toString();
+        return List.of(date);
+    }
+
+    private static ScheduleTime extractScheduleTimeFromConfirmTimes(List<LocalDateTime> confirmTimes) {
+        LocalTime startTime = confirmTimes.get(0).toLocalTime();
+        LocalTime endTime = confirmTimes.get(1).toLocalTime();
+
+        return ScheduleTime.of(startTime, endTime);
     }
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/schedule/controller/MSController.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/schedule/controller/MSController.java
@@ -3,6 +3,7 @@ package org.chzzk.howmeet.domain.regular.schedule.controller;
 import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.domain.regular.schedule.dto.MSRequest;
 import org.chzzk.howmeet.domain.regular.schedule.dto.MSResponse;
+import org.chzzk.howmeet.domain.regular.schedule.dto.ProgressedMSResponse;
 import org.chzzk.howmeet.domain.regular.schedule.service.MSService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,9 +17,9 @@ public class MSController {
     private final MSService msService;
 
     @PostMapping
-    public ResponseEntity<MSResponse> createMemberSchedule(@PathVariable Long roomId, @RequestBody final MSRequest msRequest) {
-        final MSResponse msResponse = msService.createMemberSchedule(roomId, msRequest);
-        return ResponseEntity.created(URI.create("/member-schedule/" + msResponse.id()))
+    public ResponseEntity<ProgressedMSResponse> createMemberSchedule(@PathVariable Long roomId, @RequestBody final MSRequest msRequest) {
+        final ProgressedMSResponse progressedMsResponse = msService.createMemberSchedule(roomId, msRequest);
+        return ResponseEntity.created(URI.create("/member-schedule/" + progressedMsResponse.id()))
                 .build();
     }
 

--- a/src/main/java/org/chzzk/howmeet/domain/regular/schedule/dto/MSResponse.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/schedule/dto/MSResponse.java
@@ -1,21 +1,10 @@
 package org.chzzk.howmeet.domain.regular.schedule.dto;
 
-import org.chzzk.howmeet.domain.common.embedded.date.impl.ScheduleTime;
 import org.chzzk.howmeet.domain.common.model.ScheduleName;
-import org.chzzk.howmeet.domain.regular.schedule.entity.MemberSchedule;
 import org.chzzk.howmeet.domain.regular.schedule.entity.ScheduleStatus;
 
-import java.util.List;
-
-public record MSResponse(Long id, List<String> dates, ScheduleTime time, ScheduleName name, ScheduleStatus status) {
-
-    public static MSResponse from(final MemberSchedule memberSchedule) {
-        return new MSResponse(
-                memberSchedule.getId(),
-                memberSchedule.getDates(),
-                memberSchedule.getTime(),
-                memberSchedule.getName(),
-                memberSchedule.getStatus()
-        );
-    }
+public interface MSResponse {
+    Long getId();
+    ScheduleName getName();
+    ScheduleStatus getStatus();
 }

--- a/src/main/java/org/chzzk/howmeet/domain/regular/schedule/service/MSService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/regular/schedule/service/MSService.java
@@ -1,15 +1,27 @@
 package org.chzzk.howmeet.domain.regular.schedule.service;
 
 import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.common.embedded.date.impl.ScheduleTime;
+import org.chzzk.howmeet.domain.regular.confirm.entity.ConfirmSchedule;
+import org.chzzk.howmeet.domain.regular.confirm.repository.ConfirmRepository;
 import org.chzzk.howmeet.domain.regular.room.entity.Room;
 import org.chzzk.howmeet.domain.regular.room.repository.RoomRepository;
+import org.chzzk.howmeet.domain.regular.schedule.dto.CompletedMSResponse;
 import org.chzzk.howmeet.domain.regular.schedule.dto.MSRequest;
 import org.chzzk.howmeet.domain.regular.schedule.dto.MSResponse;
+import org.chzzk.howmeet.domain.regular.schedule.dto.ProgressedMSResponse;
 import org.chzzk.howmeet.domain.regular.schedule.entity.MemberSchedule;
+import org.chzzk.howmeet.domain.regular.schedule.entity.ScheduleStatus;
 import org.chzzk.howmeet.domain.regular.schedule.exception.MSException;
 import org.chzzk.howmeet.domain.regular.schedule.repository.MSRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.chzzk.howmeet.domain.regular.schedule.exception.MSErrorCode.ROOM_NOT_FOUND;
 import static org.chzzk.howmeet.domain.regular.schedule.exception.MSErrorCode.SCHEDULE_NOT_FOUND;
@@ -20,21 +32,33 @@ import static org.chzzk.howmeet.domain.regular.schedule.exception.MSErrorCode.SC
 public class MSService {
     private final MSRepository msRepository;
     private final RoomRepository roomRepository;
+    private final ConfirmRepository confirmRepository;
 
     @Transactional
-    public MSResponse createMemberSchedule(final Long roomId, final MSRequest msRequest) {
+    public ProgressedMSResponse createMemberSchedule(final Long roomId, final MSRequest msRequest) {
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> new MSException(ROOM_NOT_FOUND));
 
         MemberSchedule memberSchedule = msRequest.toEntity(room);
         MemberSchedule savedSchedule = msRepository.save(memberSchedule);
 
-        return MSResponse.from(savedSchedule);
+        return ProgressedMSResponse.from(savedSchedule);
     }
 
     public MSResponse getMemberSchedule(final Long roomId, final Long msId) {
         MemberSchedule memberSchedule = findMemberScheduleByRoomIdAndMsId(roomId, msId);
-        return MSResponse.from(memberSchedule);
+
+        if (memberSchedule.getStatus() == ScheduleStatus.COMPLETE) {
+            ConfirmSchedule confirmSchedule = findConfirmScheduleByMSId(msId);
+            List<LocalDateTime> confirmTimes = confirmSchedule.getTimes();
+            List<String> dates = extractDatesFromConfirmTimes(confirmTimes);
+            ScheduleTime scheduleTime = extractScheduleTimeFromConfirmTimes(confirmTimes);
+            return CompletedMSResponse.of(memberSchedule, dates, scheduleTime);
+        } else if (memberSchedule.getStatus() == ScheduleStatus.PROGRESS) {
+            return ProgressedMSResponse.from(memberSchedule);
+        }
+
+        throw new IllegalStateException("알 수 없는 상태입니다.");
     }
 
     @Transactional
@@ -47,6 +71,22 @@ public class MSService {
     private MemberSchedule findMemberScheduleByRoomIdAndMsId(Long roomId, Long msId) {
         return msRepository.findByIdAndRoomId(msId, roomId)
                 .orElseThrow(() -> new MSException(SCHEDULE_NOT_FOUND));
+    }
+
+    private ConfirmSchedule findConfirmScheduleByMSId(Long memberScheduleId) {
+        return confirmRepository.findByMemberScheduleId(memberScheduleId)
+                .orElseThrow(() -> new IllegalArgumentException("일치하는 일정 결과를 찾을 수 없습니다."));
+    }
+
+    private List<String> extractDatesFromConfirmTimes(List<LocalDateTime> confirmTimes) {
+        String date = confirmTimes.get(0).toLocalDate().toString();
+        return List.of(date);
+    }
+
+    private ScheduleTime extractScheduleTimeFromConfirmTimes(List<LocalDateTime> confirmTimes) {
+        LocalTime startTime = confirmTimes.get(0).toLocalTime();
+        LocalTime endTime = confirmTimes.get(1).toLocalTime();
+        return ScheduleTime.of(startTime, endTime);
     }
 }
 

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/controller/GSController.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/controller/GSController.java
@@ -1,6 +1,7 @@
 package org.chzzk.howmeet.domain.temporary.schedule.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.chzzk.howmeet.domain.temporary.schedule.dto.GSCreateResponse;
 import org.chzzk.howmeet.domain.temporary.schedule.dto.GSRequest;
 import org.chzzk.howmeet.domain.temporary.schedule.dto.GSResponse;
 import org.chzzk.howmeet.domain.temporary.schedule.service.GSService;
@@ -17,9 +18,8 @@ public class GSController {
 
     @PostMapping
     public ResponseEntity<?> createGuestSchedule(@RequestBody final GSRequest gsRequest) {
-        final GSResponse gsResponse = gsService.createGuestSchedule(gsRequest);
-        return ResponseEntity.created(URI.create("/guest-schedule/" + gsResponse.id()))
-                .build();
+        final GSCreateResponse gsCreateResponse = gsService.createGuestSchedule(gsRequest);
+        return ResponseEntity.ok(gsCreateResponse);
     }
 
     @GetMapping("/{guestScheduleId}")

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/dto/GSCreateResponse.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/dto/GSCreateResponse.java
@@ -1,0 +1,16 @@
+package org.chzzk.howmeet.domain.temporary.schedule.dto;
+
+import org.chzzk.howmeet.domain.common.embedded.date.impl.ScheduleTime;
+import org.chzzk.howmeet.domain.common.model.ScheduleName;
+import org.chzzk.howmeet.domain.regular.schedule.entity.ScheduleStatus;
+import org.chzzk.howmeet.domain.temporary.schedule.entity.GuestSchedule;
+
+import java.util.List;
+
+public record GSCreateResponse(Long gsId) {
+    public static GSCreateResponse from(final GuestSchedule guestSchedule) {
+        return new GSCreateResponse(
+                guestSchedule.getId()
+        );
+    }
+}

--- a/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/service/GSService.java
+++ b/src/main/java/org/chzzk/howmeet/domain/temporary/schedule/service/GSService.java
@@ -2,6 +2,7 @@ package org.chzzk.howmeet.domain.temporary.schedule.service;
 
 import lombok.RequiredArgsConstructor;
 import org.chzzk.howmeet.domain.regular.schedule.entity.ScheduleStatus;
+import org.chzzk.howmeet.domain.temporary.schedule.dto.GSCreateResponse;
 import org.chzzk.howmeet.domain.temporary.schedule.dto.GSRequest;
 import org.chzzk.howmeet.domain.temporary.schedule.dto.GSResponse;
 import org.chzzk.howmeet.domain.temporary.schedule.entity.GuestSchedule;
@@ -23,10 +24,10 @@ public class GSService {
     private final GSRepository gsRepository;
 
     @Transactional
-    public GSResponse createGuestSchedule(final GSRequest gsRequest) {
+    public GSCreateResponse createGuestSchedule(final GSRequest gsRequest) {
         GuestSchedule guestSchedule = GuestSchedule.of(gsRequest.dates(), gsRequest.time(), gsRequest.name());
         GuestSchedule savedSchedule = gsRepository.save(guestSchedule);
-        return GSResponse.of(savedSchedule);
+        return GSCreateResponse.from(savedSchedule);
     }
 
     public GSResponse getGuestSchedule(final Long guestScheduleId) {


### PR DESCRIPTION
## 작업 내용
- 회원 일정 조회 출력 변경
- 비회원 일정 생성시 응답값 수정

## 테스트
회원 일정 조회(확정시, 형태는 작업하기 편해게 진행중일때과 같도록 요청하셨습니다.)
![image](https://github.com/user-attachments/assets/cd0792d8-ba97-4aef-acb8-aff44239100f)
회원 일정 조회(진행중일때)
![image](https://github.com/user-attachments/assets/399b7ca7-4ce4-49f1-93db-70d24ae8f09f)
비회원 일정 생성
![image](https://github.com/user-attachments/assets/49861ed5-35a8-4d16-8342-6d919cc3a64c)

## 기타 사항 (참고 자료, 문의 사항 등)
- 없음
